### PR TITLE
docs(examples): drop no-op web_search entries from allowedTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Use `toolset` to select a request-scoped harness preset and add bundled client
 tools. `allowedTools` remains the final visibility boundary across bundled and
 custom tools.
 
+Both are scoped to locally executed client tools. Server-side tools (such as
+`web_search`) are attached to the agent itself via `baseTools` at creation and
+are unaffected by `allowedTools` — listing one there matches nothing.
+
 ```ts
 await using session = client.createSession(agentId, {
   toolset: {

--- a/examples/economics-seminar/presenter.ts
+++ b/examples/economics-seminar/presenter.ts
@@ -51,7 +51,7 @@ export async function createPresenter(
   if (existingAgentId) {
     return resumeSession(existingAgentId, {
       model: config.model,
-      allowedTools: ['web_search', 'Read', 'Write'],
+      allowedTools: ['Read', 'Write'],
       permissionMode: 'unrestricted',
     });
   }
@@ -105,7 +105,7 @@ export async function createPresenter(
         description: 'Research approach refined over time',
       },
     ],
-    allowedTools: ['web_search', 'Read', 'Write'],
+    allowedTools: ['Read', 'Write'],
     permissionMode: 'unrestricted',
   });
 }

--- a/examples/research-team/README.md
+++ b/examples/research-team/README.md
@@ -208,7 +208,9 @@ const researcherAgentId = 'agent-xxx-yyy-zzz';
 
 // Teleport the trained researcher into your code
 const researcher = resumeSession(researcherAgentId, {
-  allowedTools: ['web_search', 'Read', 'Write'],
+  // Client-side tools only. web_search is server-side and stays attached
+  // to the agent from creation, so it needs no entry here.
+  allowedTools: ['Read', 'Write'],
   permissionMode: 'unrestricted',
 });
 

--- a/examples/research-team/agents/researcher.ts
+++ b/examples/research-team/agents/researcher.ts
@@ -120,7 +120,7 @@ export async function createResearcher(
         description: 'Accumulated knowledge of key concepts and influential works',
       },
     ],
-    allowedTools: ['web_search', 'Glob', 'Read', 'Write'],
+    allowedTools: ['Glob', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   });
 }

--- a/examples/research-team/teleport-example.ts
+++ b/examples/research-team/teleport-example.ts
@@ -55,7 +55,7 @@ async function main() {
   console.log('   and which search strategies work best.\n');
 
   const researcher = resumeSession(teamState.agentIds.researcher!, {
-    allowedTools: ['web_search', 'Read', 'Write'],
+    allowedTools: ['Read', 'Write'],
     permissionMode: 'unrestricted',
   });
 


### PR DESCRIPTION
Follow-up to the review on #253. Five example sites list `web_search` in `allowedTools`, implying that is how web access is granted. It never was.

## Why it's a no-op

`allowedTools` reaches the harness as `client_tool_allowlist`, documented in `protocol_v2.d.ts` as an "optional request-scoped allowlist for locally executed client tools." Following it through the harness confirms the scope — it resolves to `clientToolAllowlist` and is applied to exactly three registries:

```js
toolRegistry:  filterToolRegistryByClientAllowlist(...)
externalTools: filterExternalToolsByClientAllowlist(...)
modTools:      filterModToolsByClientAllowlist(...)
```

All three hold locally executed tools. Server-side tools like `web_search` are attached to the agent on the Letta server and never enter those registries, so naming one in `allowedTools` matches nothing and filters nothing.

The change is therefore behaviour-neutral: `['web_search', 'Read', 'Write']` and `['Read', 'Write']` produce an identical effective client allowlist. Those agents could search only because creation attached `web_search` by default.

## Changes

Removed the no-op entries at all five sites — `research-team/agents/researcher.ts`, `economics-seminar/presenter.ts` (×2), `research-team/teleport-example.ts`, and the `resumeSession` snippet in `research-team/README.md`.

Also documented the split in the root README, right next to the `allowedTools` description that invites the confusion: both `toolset` and `allowedTools` are scoped to client tools, while server-side tools come from `baseTools` at creation.

`bun run check`, `bun test` (206 pass / 0 fail), and `bun run build` pass.

## Overlaps #253

#253 attaches `baseTools: ['web_search']` at the two *creation* sites — that is the change that actually keeps those examples working once creation stops attaching server tools by default. This PR is the complementary half: it removes the entries that never did anything.

The two touch adjacent lines in `researcher.ts` and `presenter.ts`, so whichever merges second needs a trivial resolution (keep the `baseTools` line, keep the shortened `allowedTools` line). The remaining three sites here are independent of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)