### PR TITLE
feat: add first-class computer discovery and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,38 @@ session's `canUseTool` callback.
 | `local` | Current computer | Current computer through an SDK-managed App Server |
 | `remote` | Configured by the App Server | A user-managed App Server computer |
 
+### Choose a computer
+
+Cloud clients can list the computers registered with the current Letta account
+and select one by name when opening a session:
+
+```ts
+const { computers } = await client.computers.list({ onlineOnly: true });
+for (const computer of computers) {
+  console.log(computer.name, computer.deviceId, computer.status);
+}
+
+await using session = client.resumeSession(agentId, {
+  computer: "Work laptop",
+});
+await session.send("Run the test suite on this computer.");
+```
+
+Computer names must uniquely identify a registered computer. For persisted
+selections, use the stable `deviceId`; a `connectionId` identifies only the
+current online lease and can rotate after reconnects:
+
+```ts
+await using session = client.resumeSession(agentId, {
+  computer: { deviceId: "device-..." },
+});
+```
+
+`client.computers.get(deviceId)` retrieves one computer and
+`client.computers.resolve(selector)` resolves a name or ID to its current online
+connection. The previous client-level and session-level `environment` options
+remain as deprecated compatibility aliases for `computer`.
+
 ### Local
 
 ```ts
@@ -227,7 +259,7 @@ For authenticated Remote App Servers in React Native, pass the platform WebSocke
 
 ## Management APIs
 
-The client exposes agent, conversation, model, and Cloud repository management alongside active sessions:
+The client exposes agent, conversation, model, computer, and Cloud repository management alongside active sessions:
 
 ```ts
 const agents = await client.agents.list({ tags: ["support"] });

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -9,6 +9,11 @@ import {
 import { CloudManagementTransport } from "./cloud-management.js";
 import { createCloudClient } from "./cloud-client.js";
 import {
+  ComputersClientImpl,
+  type ComputerSelector,
+  type ComputersClient,
+} from "./computers.js";
+import {
   CloudEnvironmentSession,
   assertCloudSessionOptionsSupported,
   createCloudAgent,
@@ -55,19 +60,21 @@ function isLettaCodeBackend(value: string): value is LettaCodeBackend {
   return VALID_BACKENDS.has(value as LettaCodeBackend);
 }
 
-function getOptionsEnvironment(
+function getOptionsComputer(
   options: LettaCodeClientOptions,
-): LettaCodeEnvironment | undefined {
-  if ("environment" in options) {
-    return options.environment;
+): ComputerSelector | undefined {
+  if (!("computer" in options) && !("environment" in options)) return undefined;
+  if (options.computer !== undefined && options.environment !== undefined) {
+    throw new Error('Specify either "computer" or deprecated "environment", not both.');
   }
-  return undefined;
+  return options.computer ?? options.environment;
 }
 
 function stripCloudExecutionOptions(
   options: LettaCodeClientSessionOptions,
 ): CreateSessionOptions {
   const sessionOptions = { ...options };
+  delete sessionOptions.computer;
   delete sessionOptions.environment;
   delete sessionOptions.sandbox;
   delete sessionOptions.filesystemConfinement;
@@ -102,12 +109,15 @@ type OneShotSession = LettaCodeSession & {
  */
 export class LettaAgentClientBase {
   readonly backend: LettaCodeBackend;
+  readonly computer: ComputerSelector | undefined;
+  /** @deprecated Use `computer`. */
   readonly environment: LettaCodeEnvironment | undefined;
   readonly agents: AgentsClient;
   readonly conversations: ConversationsClient;
   readonly models: ModelsClient;
   protected readonly options: LettaCodeClientOptions;
   private repositoriesClient: RepositoriesClient | null = null;
+  private computersClient: ComputersClientImpl | null = null;
   private agentRepositoriesClient: AgentRepositoriesClient | null = null;
   private cloudClient: Letta | null = null;
   private managementTransport: ManagementTransport | null = null;
@@ -121,7 +131,8 @@ export class LettaAgentClientBase {
     }
 
     this.backend = backend;
-    this.environment = getOptionsEnvironment(options);
+    this.computer = getOptionsComputer(options);
+    this.environment = this.computer;
     this.options = options;
     this.agents = createAgentsClient(
       () => this.getManagementTransport(),
@@ -132,14 +143,20 @@ export class LettaAgentClientBase {
     );
     this.models = createModelsClient(() => this.getManagementTransport());
 
-    if (this.backend === "local" && this.environment !== undefined) {
+    if (this.backend === "local" && this.computer !== undefined) {
+      const field = "computer" in options && options.computer !== undefined
+        ? "computer"
+        : "environment";
       throw new Error(
-        'LettaAgentClient environment is only valid with backend: "cloud".',
+        `LettaAgentClient ${field} is only valid with backend: "cloud".`,
       );
     }
-    if (this.backend === "remote" && this.environment !== undefined) {
+    if (this.backend === "remote" && this.computer !== undefined) {
+      const field = "computer" in options && options.computer !== undefined
+        ? "computer"
+        : "environment";
       throw new Error(
-        'LettaAgentClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
+        `LettaAgentClient ${field} is only valid with backend: "cloud"; remote url selects the app-server runtime.`,
       );
     }
     if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
@@ -194,6 +211,11 @@ export class LettaAgentClientBase {
    */
   get repositories(): RepositoriesClient {
     return this.getRepositoriesClient();
+  }
+
+  /** Discover and resolve computers registered with this Letta Cloud account. */
+  get computers(): ComputersClient {
+    return this.getComputersClient();
   }
 
   async createAgent(options: CreateAgentOptions = {}): Promise<string> {
@@ -336,6 +358,11 @@ export class LettaAgentClientBase {
     action: string,
     options: LettaCodeClientSessionOptions,
   ): void {
+    if (options.computer !== undefined && options.environment !== undefined) {
+      throw new Error(
+        `${action}() cannot specify both computer and deprecated environment.`,
+      );
+    }
     if (
       options.filesystemConfinement !== undefined &&
       options.filesystemConfinement !== "memory"
@@ -344,11 +371,13 @@ export class LettaAgentClientBase {
         `Invalid filesystemConfinement '${String(options.filesystemConfinement)}'. Valid value: memory.`,
       );
     }
-    const effectiveEnvironment = options.environment ?? this.environment;
+    const effectiveComputer =
+      options.computer ?? options.environment ?? this.computer;
     if (this.backend === "local") {
-      if (effectiveEnvironment !== undefined) {
+      if (effectiveComputer !== undefined) {
+        const field = options.computer !== undefined ? "computer" : "environment";
         throw new Error(
-          `${action}() environment overrides are only valid with backend: "cloud".`,
+          `${action}() ${field} overrides are only valid with backend: "cloud".`,
         );
       }
       if (options.sandbox !== undefined) {
@@ -374,9 +403,10 @@ export class LettaAgentClientBase {
           `${action}() filesystemConfinement requires an SDK-owned local app-server process.`,
         );
       }
-      if (options.environment !== undefined) {
+      if (options.computer !== undefined || options.environment !== undefined) {
+        const field = options.computer !== undefined ? "computer" : "environment";
         throw new Error(
-          `${action}() environment overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
+          `${action}() ${field} overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
         );
       }
       if (options.sandbox !== undefined) {
@@ -394,11 +424,20 @@ export class LettaAgentClientBase {
         );
       }
       const cloudOptions = this.cloudOptions();
-      if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
-        throw new Error(`Letta Cloud ${action}() cannot specify sandbox options when the client has a default environment.`);
+      if (this.computer !== undefined && options.sandbox !== undefined) {
+        const field = cloudOptions.computer !== undefined
+          ? "computer"
+          : "environment";
+        throw new Error(`Letta Cloud ${action}() cannot specify sandbox options when the client has a default ${field}.`);
       }
-      if (cloudOptions.sandbox !== undefined && options.environment !== undefined) {
-        throw new Error(`Letta Cloud ${action}() cannot specify an environment when the client has default sandbox options.`);
+      if (
+        cloudOptions.sandbox !== undefined &&
+        (options.computer !== undefined || options.environment !== undefined)
+      ) {
+        const field = options.computer !== undefined
+          ? "a computer"
+          : "an environment";
+        throw new Error(`Letta Cloud ${action}() cannot specify ${field} when the client has default sandbox options.`);
       }
       assertCloudSessionOptionsSupported(action, options);
       return;
@@ -445,6 +484,14 @@ export class LettaAgentClientBase {
 
   private appServerSessionOptions(): AppServerSessionOptions {
     return this.remoteOptions();
+  }
+
+  private getComputersClient(): ComputersClientImpl {
+    if (this.backend !== "cloud") {
+      throw new Error('client.computers is only available with backend: "cloud".');
+    }
+    this.computersClient ??= new ComputersClientImpl(this.getCloudClient());
+    return this.computersClient;
   }
 
   private getRepositoriesClient(): RepositoriesClient {

--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -25,6 +25,15 @@ export class LettaAgentClient extends LettaAgentClientBase {
 
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 export { RepositoriesClient } from "./repositories.js";
+export type {
+  Computer,
+  ComputerMetadata,
+  ComputerSelector,
+  ComputersClient,
+  ListComputersOptions,
+  ListComputersResult,
+  ResolvedComputer,
+} from "./computers.js";
 export type * from "./management-types.js";
 export { extractStreamTextDelta } from "./stream-events.js";
 export { createReactNativeWebSocketConstructor } from "./websocket.js";

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -171,8 +171,19 @@ function validatePositiveInteger(value: number | undefined, name: string): void 
 export function validateCloudClientOptions(options: LettaCodeCloudClientOptions): void {
   validatePositiveInteger(options.requestTimeoutMs, "requestTimeoutMs");
   validateCloudSandboxOptions(options.sandbox, "sandbox");
-  if (options.environment !== undefined && options.sandbox !== undefined) {
-    throw new Error("Letta Cloud sessions cannot specify both environment and sandbox options.");
+  if (options.computer !== undefined && options.environment !== undefined) {
+    throw new Error(
+      "Letta Cloud clients cannot specify both computer and deprecated environment.",
+    );
+  }
+  if (
+    (options.computer !== undefined || options.environment !== undefined) &&
+    options.sandbox !== undefined
+  ) {
+    const field = options.computer !== undefined ? "computer" : "environment";
+    throw new Error(
+      `Letta Cloud sessions cannot specify both ${field} and sandbox options.`,
+    );
   }
   if (
     options.webSocketAuth !== undefined &&
@@ -982,10 +993,12 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private effectiveEnvironment(): LettaCodeEnvironment | undefined {
-    const modeEnvironment = this.mode.kind === "session"
-      ? this.mode.options.environment
+    const modeComputer = this.mode.kind === "session"
+      ? this.mode.options.computer ?? this.mode.options.environment
       : undefined;
-    return modeEnvironment ?? this.cloudOptions.environment;
+    return modeComputer ??
+      this.cloudOptions.computer ??
+      this.cloudOptions.environment;
   }
 
   private effectiveSandboxOptions(): LettaCodeCloudSandboxOptions | undefined {

--- a/src/computers.ts
+++ b/src/computers.ts
@@ -1,0 +1,132 @@
+import type { Letta } from "@letta-ai/letta-client";
+import {
+  RemoteEnvironmentClient,
+  type RemoteEnvironmentConnection,
+  type RemoteEnvironmentTarget,
+} from "./remote.js";
+
+/**
+ * Selects the computer where a Cloud session runs tools and accesses files.
+ *
+ * Strings are treated as human-readable computer names. Prefer `deviceId` when
+ * persisting a selection because connection IDs can rotate after reconnects.
+ */
+export type ComputerSelector =
+  | string
+  | { name: string }
+  | { id: string }
+  | { connectionId: string }
+  | { deviceId: string };
+
+export interface ComputerMetadata {
+  os?: string;
+  lettaCodeVersion?: string;
+  nodeVersion?: string;
+  workingDirectory?: string;
+  gitBranch?: string;
+  [key: string]: unknown;
+}
+
+/** A registered computer that can host Letta agent tool execution. */
+export interface Computer {
+  /** Environment record ID. */
+  id: string;
+  /** Stable identifier for the physical device across reconnects. */
+  deviceId: string;
+  /** Current online connection lease. This may rotate after reconnects. */
+  connectionId: string | null;
+  /** Human-readable computer name. */
+  name: string;
+  status: "online" | "offline";
+  connectedAt: number | null;
+  lastSeenAt: number;
+  metadata?: ComputerMetadata;
+}
+
+export interface ListComputersOptions {
+  limit?: number;
+  after?: string;
+  onlineOnly?: boolean;
+}
+
+export interface ListComputersResult {
+  computers: Computer[];
+  hasNextPage: boolean;
+}
+
+export interface ResolvedComputer {
+  connectionId: string;
+  /** Omitted when resolving an explicit connection ID. */
+  computer?: Computer;
+}
+
+export interface ComputersClient {
+  list(options?: ListComputersOptions): Promise<ListComputersResult>;
+  get(deviceId: string): Promise<Computer>;
+  resolve(selector: ComputerSelector): Promise<ResolvedComputer>;
+}
+
+function selectorToRemoteTarget(
+  selector: ComputerSelector,
+): RemoteEnvironmentTarget {
+  if (typeof selector === "string") return { connectionName: selector };
+  if ("name" in selector) return { connectionName: selector.name };
+  if ("id" in selector) return { environmentId: selector.id };
+  if ("connectionId" in selector) {
+    return { connectionId: selector.connectionId };
+  }
+  return { deviceId: selector.deviceId };
+}
+
+function toComputer(environment: RemoteEnvironmentConnection): Computer {
+  return {
+    id: environment.id,
+    deviceId: environment.deviceId,
+    connectionId: environment.connectionId,
+    name: environment.connectionName,
+    status: environment.connectionId ? "online" : "offline",
+    connectedAt: environment.connectedAt,
+    lastSeenAt: environment.lastSeenAt,
+    metadata: environment.metadata,
+  };
+}
+
+/** Public Cloud computer discovery and selection client. */
+export class ComputersClientImpl implements ComputersClient {
+  private readonly environments: RemoteEnvironmentClient;
+
+  constructor(client: Letta) {
+    this.environments = new RemoteEnvironmentClient({}, client);
+  }
+
+  async list(
+    options: ListComputersOptions = {},
+  ): Promise<ListComputersResult> {
+    const result = await this.environments.listEnvironments(options);
+    return {
+      computers: result.connections.map(toComputer),
+      hasNextPage: result.hasNextPage,
+    };
+  }
+
+  async get(deviceId: string): Promise<Computer> {
+    if (typeof deviceId !== "string" || deviceId.trim().length === 0) {
+      throw new Error("Invalid deviceId. Expected a non-empty string.");
+    }
+    return toComputer(
+      await this.environments.getEnvironmentByDeviceId(deviceId),
+    );
+  }
+
+  async resolve(selector: ComputerSelector): Promise<ResolvedComputer> {
+    const result = await this.environments.resolveEnvironment(
+      selectorToRemoteTarget(selector),
+    );
+    return {
+      connectionId: result.connectionId,
+      computer: result.environment
+        ? toComputer(result.environment)
+        : undefined,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,15 @@ export type {
 } from "./management-types.js";
 
 export { RepositoriesClient } from "./repositories.js";
+export type {
+  Computer,
+  ComputerMetadata,
+  ComputerSelector,
+  ComputersClient,
+  ListComputersOptions,
+  ListComputersResult,
+  ResolvedComputer,
+} from "./computers.js";
 export { LettaAgentClient } from "./client.js";
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 export { createReactNativeWebSocketConstructor } from "./websocket.js";

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -35,6 +35,12 @@ export interface RemoteEnvironmentConnection {
   metadata?: Record<string, unknown>;
 }
 
+export interface RemoteEnvironmentListOptions {
+  limit?: number;
+  after?: string;
+  onlineOnly?: boolean;
+}
+
 export interface RemoteEnvironmentListResult {
   connections: RemoteEnvironmentConnection[];
   hasNextPage: boolean;
@@ -59,7 +65,7 @@ function ensureOnline(
           : "connectionName" in target
             ? target.connectionName
             : environment.deviceId;
-    throw new Error(`Remote environment is offline: ${label}`);
+    throw new Error(`Computer is offline: ${label}`);
   }
 
   return {
@@ -84,8 +90,16 @@ export class RemoteEnvironmentClient {
     }),
   ) {}
 
-  async listEnvironments(): Promise<RemoteEnvironmentListResult> {
-    return await this.client.environments.list() as RemoteEnvironmentListResult;
+  async listEnvironments(
+    options: RemoteEnvironmentListOptions = {},
+  ): Promise<RemoteEnvironmentListResult> {
+    return await this.client.environments.list({
+      after: options.after,
+      limit: options.limit === undefined ? undefined : String(options.limit),
+      onlineOnly: options.onlineOnly === undefined
+        ? undefined
+        : String(options.onlineOnly),
+    }) as RemoteEnvironmentListResult;
   }
 
   async getEnvironmentByDeviceId(deviceId: string): Promise<RemoteEnvironmentConnection> {
@@ -103,7 +117,15 @@ export class RemoteEnvironmentClient {
       return ensureOnline(await this.getEnvironmentByDeviceId(target.deviceId), target);
     }
 
-    const { connections } = await this.listEnvironments();
+    const connections: RemoteEnvironmentConnection[] = [];
+    let after: string | undefined;
+    do {
+      const page = await this.listEnvironments({ limit: 100, after });
+      connections.push(...page.connections);
+      if (!page.hasNextPage || page.connections.length === 0) break;
+      after = page.connections.at(-1)?.id;
+    } while (after !== undefined);
+
     if ("environmentId" in target) {
       const match = connections.find((env) => env.id === target.environmentId);
       if (!match) {
@@ -116,17 +138,24 @@ export class RemoteEnvironmentClient {
       (env) => env.connectionName === target.connectionName,
     );
     if (matches.length === 0) {
-      throw new Error(`Remote environment not found: ${target.connectionName}`);
+      throw new Error(`Computer not found: ${target.connectionName}`);
     }
-    if (matches.length > 1) {
+    const onlineMatches = matches.filter(
+      (environment) => environment.connectionId !== null,
+    );
+    if (onlineMatches.length === 0) {
+      throw new Error(`Computer is offline: ${target.connectionName}`);
+    }
+    if (onlineMatches.length > 1) {
+      const candidates = onlineMatches
+        .map((environment) =>
+          `${environment.connectionName} (${environment.deviceId}, online)`
+        )
+        .join(", ");
       throw new Error(
-        `Remote environment name is ambiguous: ${target.connectionName}`,
+        `Computer name is ambiguous: ${target.connectionName}. Matches: ${candidates}. Select one by deviceId.`,
       );
     }
-    const match = matches[0];
-    if (!match) {
-      throw new Error(`Remote environment not found: ${target.connectionName}`);
-    }
-    return ensureOnline(match, target);
+    return ensureOnline(onlineMatches[0]!, target);
   }
 }

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -882,11 +882,12 @@ describe("LettaAgentClient", () => {
     });
     const cloudClient = new LettaAgentClient({
       backend: "cloud",
-      environment: { name: "LettaDevelopers" },
+      computer: { name: "LettaDevelopers" },
     });
 
     expect(remoteClient.backend).toBe("remote");
     expect(cloudClient.backend).toBe("cloud");
+    expect(cloudClient.computer).toEqual({ name: "LettaDevelopers" });
     expect(cloudClient.environment).toEqual({ name: "LettaDevelopers" });
   });
 
@@ -912,6 +913,24 @@ describe("LettaAgentClient", () => {
     } finally {
       session.close();
     }
+  });
+
+  test("rejects conflicting computer and environment selectors", () => {
+    expect(() =>
+      new LettaAgentClient({
+        backend: "cloud",
+        computer: "Work laptop",
+        environment: "legacy-name",
+      }),
+    ).toThrow('either "computer" or deprecated "environment"');
+
+    const client = new LettaAgentClient({ backend: "cloud" });
+    expect(() =>
+      client.resumeSession("agent-123", {
+        computer: "Work laptop",
+        environment: "legacy-name",
+      }),
+    ).toThrow("cannot specify both computer and deprecated environment");
   });
 
   test("constructs cloud backend sessions without using the local fallback", () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1313,7 +1313,7 @@ describe("CloudEnvironmentSession", () => {
     )).toHaveLength(0);
   });
 
-  test("uses an explicit environment before using the Remote Client websocket", async () => {
+  test("uses an explicit computer before using the Remote Client websocket", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -1323,7 +1323,7 @@ describe("CloudEnvironmentSession", () => {
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
       requestTimeoutMs: 1_000,
-      environment: { connectionId: "conn-explicit" },
+      computer: { connectionId: "conn-explicit" },
     });
 
     const session = client.resumeSession("agent-1", {

--- a/src/tests/computers.test.ts
+++ b/src/tests/computers.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import { LettaAgentClient } from "../client-entry.js";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+function createFetchMock(
+  handler: (url: URL, init?: RequestInit) => Response,
+): typeof fetch {
+  return ((input: FetchInput | URL, init?: RequestInit) =>
+    Promise.resolve(handler(new URL(String(input)), init))) as typeof fetch;
+}
+
+const onlineComputer = {
+  id: "env-1",
+  connectionId: "conn-1",
+  deviceId: "device-1",
+  connectionName: "Work laptop",
+  organizationId: "org-1",
+  podId: "pod-1",
+  connectedAt: 10,
+  lastHeartbeat: 20,
+  lastSeenAt: 30,
+  firstSeenAt: 1,
+  metadata: {
+    os: "darwin",
+    workingDirectory: "/workspace/project",
+  },
+};
+
+function cloudClient(fetchMock: typeof fetch): LettaAgentClient {
+  return new LettaAgentClient({
+    backend: "cloud",
+    apiBaseUrl: "https://api.test",
+    apiKey: "sk-test",
+    fetch: fetchMock,
+  });
+}
+
+describe("client.computers", () => {
+  test("lists computers with filters and normalizes product-facing fields", async () => {
+    const requests: URL[] = [];
+    const client = cloudClient(
+      createFetchMock((url) => {
+        requests.push(url);
+        return jsonResponse({
+          connections: [
+            onlineComputer,
+            {
+              ...onlineComputer,
+              id: "env-2",
+              deviceId: "device-2",
+              connectionId: null,
+              connectionName: "Home desktop",
+              connectedAt: null,
+            },
+          ],
+          hasNextPage: true,
+        });
+      }),
+    );
+
+    const result = await client.computers.list({
+      limit: 2,
+      after: "env-previous",
+      onlineOnly: false,
+    });
+
+    expect(result).toEqual({
+      computers: [
+        {
+          id: "env-1",
+          deviceId: "device-1",
+          connectionId: "conn-1",
+          name: "Work laptop",
+          status: "online",
+          connectedAt: 10,
+          lastSeenAt: 30,
+          metadata: {
+            os: "darwin",
+            workingDirectory: "/workspace/project",
+          },
+        },
+        {
+          id: "env-2",
+          deviceId: "device-2",
+          connectionId: null,
+          name: "Home desktop",
+          status: "offline",
+          connectedAt: null,
+          lastSeenAt: 30,
+          metadata: {
+            os: "darwin",
+            workingDirectory: "/workspace/project",
+          },
+        },
+      ],
+      hasNextPage: true,
+    });
+    expect(requests[0]?.pathname).toBe("/v1/environments");
+    expect(requests[0]?.searchParams.get("limit")).toBe("2");
+    expect(requests[0]?.searchParams.get("after")).toBe("env-previous");
+    expect(requests[0]?.searchParams.get("onlineOnly")).toBe("false");
+  });
+
+  test("gets and resolves a computer by stable device ID", async () => {
+    const client = cloudClient(
+      createFetchMock((url) => {
+        expect(url.pathname).toBe("/v1/environments/device-1");
+        return jsonResponse(onlineComputer);
+      }),
+    );
+
+    await expect(client.computers.get("device-1")).resolves.toMatchObject({
+      name: "Work laptop",
+      deviceId: "device-1",
+      status: "online",
+    });
+    await expect(
+      client.computers.resolve({ deviceId: "device-1" }),
+    ).resolves.toMatchObject({
+      connectionId: "conn-1",
+      computer: { name: "Work laptop", deviceId: "device-1" },
+    });
+  });
+
+  test("resolves a unique computer name and reports ambiguous candidates", async () => {
+    let ambiguous = false;
+    const client = cloudClient(
+      createFetchMock(() =>
+        jsonResponse({
+          connections: ambiguous
+            ? [
+                onlineComputer,
+                {
+                  ...onlineComputer,
+                  id: "env-2",
+                  deviceId: "device-2",
+                  connectionId: "conn-2",
+                },
+              ]
+            : [
+                onlineComputer,
+                {
+                  ...onlineComputer,
+                  id: "env-offline",
+                  deviceId: "device-offline",
+                  connectionId: null,
+                },
+              ],
+          hasNextPage: false,
+        })
+      ),
+    );
+
+    await expect(client.computers.resolve("Work laptop")).resolves.toMatchObject({
+      connectionId: "conn-1",
+      computer: { name: "Work laptop" },
+    });
+
+    ambiguous = true;
+    await expect(client.computers.resolve({ name: "Work laptop" })).rejects.toThrow(
+      "device-1, online",
+    );
+    await expect(client.computers.resolve({ name: "Work laptop" })).rejects.toThrow(
+      "Select one by deviceId",
+    );
+  });
+
+  test("is only available on the Cloud backend", () => {
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://localhost:4500",
+    });
+    expect(() => client.computers).toThrow(
+      'client.computers is only available with backend: "cloud"',
+    );
+  });
+});

--- a/src/tests/remote.test.ts
+++ b/src/tests/remote.test.ts
@@ -85,7 +85,7 @@ describe("RemoteEnvironmentClient", () => {
 
     await expect(
       client.resolveEnvironment({ connectionName: "work-laptop" }),
-    ).rejects.toThrow("Remote environment name is ambiguous");
+    ).rejects.toThrow("Computer name is ambiguous");
   });
 
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ import type {
 import type { Message as LettaMessage } from "@letta-ai/letta-client/resources/agents/messages";
 import type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 import type { LettaCodeCloudSandboxOptions } from "./cloud-sandbox.js";
+import type { ComputerSelector } from "./computers.js";
 export type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 export type {
   GitHubRepositoryRef,
@@ -301,18 +302,8 @@ export type McpServers = Record<string, McpServerConfig>;
  */
 export type LettaCodeBackend = "local" | "remote" | "cloud";
 
-/**
- * Stable execution target for remote/cloud runtimes.
- *
- * Strings are treated as human-readable environment names. Object forms allow
- * callers to avoid relying on names as unique identifiers.
- */
-export type LettaCodeEnvironment =
-  | string
-  | { name: string }
-  | { id: string }
-  | { connectionId: string }
-  | { deviceId: string };
+/** @deprecated Use `ComputerSelector` from the package root. */
+export type LettaCodeEnvironment = ComputerSelector;
 
 export interface LettaCodeLocalAppServerOptions {
   /**
@@ -383,11 +374,13 @@ export interface LettaCodeCloudClientOptions {
   /** Heartbeat interval for the Cloud status websocket. Defaults to 30s. */
   pingIntervalMs?: number;
   /**
-   * Execution target for Letta Cloud sessions. If omitted, the SDK creates
-   * and owns a sandbox for the session.
+   * Computer where Letta Cloud sessions run. If omitted, the SDK creates and
+   * owns a managed sandbox for the session.
    */
+  computer?: ComputerSelector;
+  /** @deprecated Use `computer`. */
   environment?: LettaCodeEnvironment;
-  /** Options for SDK-managed sandboxes when environment is omitted. */
+  /** Options for SDK-managed sandboxes when no computer is selected. */
   sandbox?: LettaCodeCloudSandboxOptions;
 }
 
@@ -709,12 +702,14 @@ export interface CreateSessionOptions {
 /**
  * Session options accepted by LettaAgentClient methods.
  *
- * `environment` is a cloud execution-target override. It is deliberately
+ * `computer` is a Cloud execution-target override. It is deliberately
  * session-scoped rather than part of createAgent() options.
  */
 export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
+  computer?: ComputerSelector;
+  /** @deprecated Use `computer`. */
   environment?: LettaCodeEnvironment;
-  /** Per-session SDK-managed sandbox options when environment is omitted. */
+  /** Per-session SDK-managed sandbox options when no computer is selected. */
   sandbox?: LettaCodeCloudSandboxOptions;
   /**
    * Extra environment variables for the session's harness process. Each


### PR DESCRIPTION
## Summary

- expose `client.computers.list()`, `get()`, and `resolve()` for computers registered with Letta Cloud
- allow Cloud sessions to select a computer by name, environment record ID, stable device ID, or active connection ID through the new `computer` option
- retain `environment` as a deprecated compatibility alias and reject conflicting selectors
- resolve names across all pages, prefer the unique online registration, and report candidate device IDs when a name is ambiguous

This aligns the Agent SDK with Letta’s public Computers terminology while continuing to use the existing `/v1/environments` transport internally.

Validated with `bun run check`, the full `bun test` suite (213 passing, 11 live tests skipped), and `bun run build`.

👾 Generated with [Letta Code](https://letta.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letta-ai/codesmith/letta-agent-sdk/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788473360&installation_model_id=430896&pr_number=258&repository=letta-ai%2Fletta-agent-sdk&return_to=https%3A%2F%2Fgithub.com%2Fletta-ai%2Fletta-agent-sdk%2Fpull%2F258&signature=3b94ea79b41ffefa945b3a00664dc84c8e73da08a5ca8d6e265a0f020b0966da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->