### PR TITLE
fix: load bundled client tools named in allowedTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ Local execution (embedded Letta Code harness / app server) requires Node.js 22.1
 
 Use `toolset` to select a request-scoped harness preset and add bundled client
 tools. `allowedTools` remains the final visibility boundary across bundled and
-custom tools.
+custom tools, and a bundled client tool named there is also loaded, so a
+session that just needs a few tools can pass `allowedTools` on its own. Pass
+`toolset` when the base itself matters — it takes precedence.
 
 Both are scoped to locally executed client tools. Server-side tools (such as
 `web_search`) are attached to the agent itself via `baseTools` at creation and

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -13,6 +13,7 @@ import type {
 } from "@letta-ai/letta-code/app-server-protocol";
 import { createAgentBody } from "./agent-creation.js";
 import { normalizeAppServerModels } from "./app-server-models.js";
+import { resolveClientToolset } from "./client-toolset.js";
 import {
   buildCanUseToolContext,
   isHeadlessAutoAllowTool,
@@ -636,11 +637,14 @@ export class AppServerSession extends RemoteClientSessionCore {
 
       const tools = agentToolNames(response.agent);
       const skillSources = options.skillSources;
-      const clientToolset = "toolset" in options ? options.toolset : undefined;
       const mcpToolNames = this.mcpBridge?.tools.map((tool) => tool.name) ?? [];
       const allowedTools = expandMcpToolWildcards(
         options.allowedTools,
         mcpToolNames,
+      );
+      const clientToolset = resolveClientToolset(
+        "toolset" in options ? options.toolset : undefined,
+        allowedTools,
       );
       const availableTools =
         tools === undefined && mcpToolNames.length === 0

--- a/src/client-toolset.ts
+++ b/src/client-toolset.ts
@@ -1,0 +1,46 @@
+import type { ClientToolsetConfig } from "./types.js";
+
+/**
+ * Bundled client tools the SDK loads on demand when a caller names them in
+ * `allowedTools`.
+ *
+ * This set is a filter, never an authority: a name it does not contain is
+ * dropped rather than forwarded, because the harness fails the turn outright
+ * on an unrecognized `client_toolset.include` entry. A tool missing here is
+ * therefore only a missed convenience — the caller can still load it with an
+ * explicit `toolset`.
+ */
+const LOADABLE_CLIENT_TOOLS: ReadonlySet<string> = new Set([
+  "Bash",
+  "Edit",
+  "Glob",
+  "Grep",
+  "LS",
+  "Read",
+  "Write",
+]);
+
+/**
+ * Resolve the request-scoped toolset to send with a turn.
+ *
+ * `allowedTools` is a visibility filter applied to the tools the harness has
+ * loaded, so naming a bundled tool there does not load it. Without this,
+ * `allowedTools: ["Read", "LS", "Glob", "Grep"]` yields a session that can
+ * only call `Read` — the other three were never loaded, and the caller sees
+ * an agent that silently fails to find anything instead of an error.
+ *
+ * An explicit `toolset` always wins; it is the caller stating exactly which
+ * base and additions they want.
+ */
+export function resolveClientToolset(
+  toolset: ClientToolsetConfig | undefined,
+  allowedTools: readonly string[] | undefined,
+): ClientToolsetConfig | undefined {
+  if (toolset !== undefined) return toolset;
+  if (allowedTools === undefined) return undefined;
+
+  const include = [
+    ...new Set(allowedTools.filter((name) => LOADABLE_CLIENT_TOOLS.has(name))),
+  ];
+  return include.length > 0 ? { include } : undefined;
+}

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -13,6 +13,7 @@ import {
   externalToolGroups,
   registerAppServerControlRequestHandler,
 } from "./app-server-session.js";
+import { resolveClientToolset } from "./client-toolset.js";
 import { createCloudStatusTransportConstructor } from "./cloud-status-transport.js";
 import {
   connectMcpServers,
@@ -413,11 +414,14 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
       const tools = agentToolNames(response.agent);
       const skillSources = options.skillSources;
-      const clientToolset = "toolset" in options ? options.toolset : undefined;
       const mcpToolNames = this.mcpBridge?.tools.map((tool) => tool.name) ?? [];
       const allowedTools = expandMcpToolWildcards(
         options.allowedTools,
         mcpToolNames,
+      );
+      const clientToolset = resolveClientToolset(
+        "toolset" in options ? options.toolset : undefined,
+        allowedTools,
       );
       const availableTools =
         tools === undefined && mcpToolNames.length === 0

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1056,6 +1056,96 @@ describe("LettaAgentClient", () => {
     }
   });
 
+  test("allowedTools loads the bundled client tools it names", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123", {
+      allowedTools: ["Read", "LS", "Glob", "Grep", "mcp__files__read", "MyCustomTool"],
+    });
+    try {
+      await asAdvanced(session).initialize();
+      await asAdvanced(session).sendAndWaitForResult("hello");
+
+      const inputCommand = fakeControlSocket().sent.find(
+        (command): command is Record<string, unknown> =>
+          typeof command === "object" && command !== null && "type" in command && command.type === "input",
+      );
+      const payload = inputCommand?.payload as Record<string, unknown> | undefined;
+      // The base stays the harness preference; only the named bundled tools
+      // are added. MCP and custom tool names are never forwarded — the
+      // harness fails the turn on an unrecognized include.
+      expect(payload?.client_toolset).toEqual({ include: ["Read", "LS", "Glob", "Grep"] });
+      expect(payload?.client_tool_allowlist).toEqual([
+        "Read",
+        "LS",
+        "Glob",
+        "Grep",
+        "mcp__files__read",
+        "MyCustomTool",
+      ]);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("an explicit toolset wins over allowedTools", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123", {
+      toolset: { base: "none", include: ["Read"] },
+      allowedTools: ["Read", "Bash"],
+    });
+    try {
+      await asAdvanced(session).initialize();
+      await asAdvanced(session).sendAndWaitForResult("hello");
+
+      const inputCommand = fakeControlSocket().sent.find(
+        (command): command is Record<string, unknown> =>
+          typeof command === "object" && command !== null && "type" in command && command.type === "input",
+      );
+      const payload = inputCommand?.payload as Record<string, unknown> | undefined;
+      expect(payload?.client_toolset).toEqual({ base: "none", include: ["Read"] });
+    } finally {
+      session.close();
+    }
+  });
+
+  test("an allowlist of only non-bundled tools sends no toolset", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123", {
+      allowedTools: ["mcp__files__read"],
+    });
+    try {
+      await asAdvanced(session).initialize();
+      await asAdvanced(session).sendAndWaitForResult("hello");
+
+      const inputCommand = fakeControlSocket().sent.find(
+        (command): command is Record<string, unknown> =>
+          typeof command === "object" && command !== null && "type" in command && command.type === "input",
+      );
+      const payload = inputCommand?.payload as Record<string, unknown> | undefined;
+      expect(payload).not.toHaveProperty("client_toolset");
+    } finally {
+      session.close();
+    }
+  });
+
   test("websocket protocol sessions respond to can_use_tool control requests through the shared approval bridge", async () => {
     FakeAppServerSocket.instances = [];
     const approvals: Array<{ toolName: string; input: Record<string, unknown> }> = [];


### PR DESCRIPTION
`allowedTools` was a visibility filter only, so naming a bundled client tool there did not load it. `allowedTools: ["Read", "LS", "Glob", "Grep"]` produced a session that could only call `Read` — the other three were never loaded — and the agent silently found nothing instead of erroring.

Bundled client tools named in `allowedTools` are now added to the request-scoped toolset. An explicit `toolset` still wins.

The names are filtered against a known set rather than forwarded as-is: the harness fails the turn on an unrecognized `client_toolset.include` entry, so MCP and custom tool names must not be passed through.

Before / after, same options (`allowedTools: ["Read", "LS", "Glob", "Grep"]`, no `toolset`):

```
before: Read, Agent, Skill
after:  Read, LS, Glob, Grep
```
