### PR TITLE
docs(examples): add dynamic workflow examples

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,53 @@
+# Dynamic Workflows
+
+Script-orchestrated multi-agent workflows built on the Letta Agent SDK, following the shape of [Claude Code dynamic workflows](https://code.claude.com/docs/en/workflows): the script holds the loop, the branching, and the intermediate results; agents do the reading, editing, and command-running.
+
+`runtime.ts` provides the primitives:
+
+- `agent(task, opts)` — spawn one ephemeral worker agent, resolve to its final text (or a parsed value when `opts.schema` is set). Resolves to `null` on failure instead of rejecting.
+- `parallel(thunks)` — run tasks concurrently with a barrier.
+- `pipeline(items, ...stages)` — run each item through stages independently, no barrier between stages.
+- `phase(title)` / `log(msg)` — progress narration.
+
+Workers are hidden agents created without memfs, run as one-shot conversations with `permissionMode: 'unrestricted'`, and are deleted when they finish. Concurrency is capped (`LETTA_WORKFLOW_CONCURRENCY`, default 4); the model defaults to `haiku` (`LETTA_WORKFLOW_MODEL`), and any Letta model handle works per-agent, so a single workflow can mix providers.
+
+## Choosing a backend
+
+`audit-files` and `fix-until-pass` run on the local backend, where workers read and edit the working directory directly. `plan-panel`, `research-sources`, and `migrate-files` route workers through a cloud client with `setWorkflowClient()`, because they need something the local backend does not provide:
+
+- **Every provider.** Model handles select the provider per agent, so a workflow can mix Anthropic, OpenAI, and Moonshot in one panel — but only for providers the deployment holds credentials for. Letta Cloud reaches the whole catalog; a local backend reaches whatever this machine is configured for.
+- **Server-side tools.** `web_search` and `fetch_webpage` are executed by the Letta server and attach via `baseTools` at agent creation. Ask a worker without them to search and it will emit a plausible, wrong answer rather than fail.
+- **Isolated filesystems.** Each cloud session gets its own managed sandbox, so a hundred workers can edit the same file without conflicting. That is what makes parallel migration safe.
+
+Cloud also parallelizes far better: local workers each spawn their own app-server process, so a 16-agent local audit took about 34 minutes here, while cloud agents of the same size returned in 10–30 seconds each.
+
+Gotchas the runtime handles for you:
+
+- Workers ask for `toolset: { base: 'none', include: [...] }` so a stage gets exactly the tools it names and nothing else — no inherited base, no browser or task tools a file auditor has no use for.
+- Managed sandboxes clone into `/root/workspace/<repo>`, and a worker left in `/root` has the agent state tree below it, so the harness's cross-agent memory guard denies every recursive path tool. `sandboxRepo()` returns the sandbox and the `cwd` that avoids this.
+- A cloud worker with no sandbox repository starts in an empty home directory. Tell it so; otherwise it "explores" nothing and invents file paths.
+- Turns fail transiently, so `agent()` retries a failed turn once. Anything still failing resolves to `null` and the fan-out continues without it.
+- Don't route a whole file back through a worker's return value. It truncates silently, and inlining a large file into a follow-up prompt fails the turn outright. `migrate-files` returns a `git diff` instead: compact enough to review, and a truncated patch fails to apply rather than corrupting a file.
+
+## Examples
+
+```bash
+# Audit files for an issue, adversarially verify each finding
+bun examples/workflows/audit-files.ts src "missing error handling around I/O"
+
+# Run a check, fix failures in parallel, repeat until it passes or stalls
+bun examples/workflows/fix-until-pass.ts "bunx tsc --noEmit"
+
+# Draft a plan from three angles on three providers (Anthropic, OpenAI,
+# Moonshot), judge, synthesize the winner. Override with PANEL_MODELS / JUDGE_MODEL.
+LETTA_API_KEY=... PANEL_REPO=letta-ai/letta-agent-sdk \
+  bun examples/workflows/plan-panel.ts "add retry logic to the websocket transport"
+
+# Research a question: fan out searchers (server-side web_search),
+# cross-check every claim against independent sources
+LETTA_API_KEY=... bun examples/workflows/research-sources.ts "what changed in bun 1.3"
+
+# Migrate files in parallel, each in its own isolated cloud sandbox clone.
+# Collects reviewed patches into ./migrated/ for `git apply`.
+LETTA_API_KEY=... bun examples/workflows/migrate-files.ts letta-ai/letta-agent-sdk examples "convert var to const"
+```

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -27,6 +27,7 @@ Gotchas the runtime handles for you:
 - Managed sandboxes clone into `/root/workspace/<repo>`, and a worker left in `/root` has the agent state tree below it, so the harness's cross-agent memory guard denies every recursive path tool. `sandboxRepo()` returns the sandbox and the `cwd` that avoids this.
 - A cloud worker with no sandbox repository starts in an empty home directory. Tell it so; otherwise it "explores" nothing and invents file paths.
 - Turns fail transiently, so `agent()` retries a failed turn once. Anything still failing resolves to `null` and the fan-out continues without it.
+- A stage that must not modify anything says so with `permissionMode: 'strict'` plus a `canUseTool` that allows reads only — there is no read-only mode, and a tool allowlist decides what a worker is offered, not what it may do. When allowing a call, return `{ behavior: 'allow' }` with no `updatedInput`: supplying one *replaces* the tool's arguments, so `{}` strips every call's parameters and the worker flails against tools that suddenly take no input.
 - Don't route a whole file back through a worker's return value. It truncates silently, and inlining a large file into a follow-up prompt fails the turn outright. `migrate-files` returns a `git diff` instead: compact enough to review, and a truncated patch fails to apply rather than corrupting a file.
 
 ## Examples

--- a/examples/workflows/audit-files.ts
+++ b/examples/workflows/audit-files.ts
@@ -1,0 +1,131 @@
+/**
+ * Audit workflow: fan out one auditor per file, adversarially verify each
+ * finding before reporting it.
+ *
+ * Usage:
+ *   bun examples/workflows/audit-files.ts [directory] ["concern"]
+ *
+ * Defaults to auditing src/ for missing error handling.
+ */
+
+import { agent, parallel, pipeline, phase, log, printSummary } from './runtime.js';
+
+const directory = process.argv[2] ?? 'src';
+const concern = process.argv[3] ?? 'missing error handling around I/O, network, and subprocess calls';
+const MAX_FILES = 15;
+
+const READ_TOOLS = ['Read', 'Grep', 'Glob', 'LS'];
+
+interface Finding {
+  file: string;
+  line: number;
+  summary: string;
+  severity: 'low' | 'medium' | 'high';
+}
+
+interface Verdict {
+  confirmed: boolean;
+  reason: string;
+}
+
+phase('Discover');
+const discovered = await agent<{ files: string[] }>(
+  `List the TypeScript source files directly under ${directory}/ (not tests, not generated files). Use Glob. Return paths relative to the repository root, e.g. "${directory}/foo.ts".`,
+  {
+    label: `list ${directory}/`,
+    allowedTools: READ_TOOLS,
+    cwd: process.cwd(),
+    schema: {
+      type: 'object',
+      required: ['files'],
+      properties: { files: { type: 'array', items: { type: 'string' } } },
+    },
+  },
+);
+
+if (!discovered || discovered.files.length === 0) {
+  console.error('Discovery failed or found no files.');
+  process.exit(1);
+}
+
+let files = discovered.files;
+if (files.length > MAX_FILES) {
+  log(`Auditing first ${MAX_FILES} of ${files.length} files (${files.length - MAX_FILES} dropped).`);
+  files = files.slice(0, MAX_FILES);
+}
+
+phase('Audit and verify');
+// Each file flows through audit → verify independently: findings in one file
+// are being verified while other files are still being audited.
+const results = await pipeline(
+  files,
+  (file: string) =>
+    agent<{ findings: Finding[] }>(
+      `Audit ${file} for: ${concern}. Read the file and report real issues only — an empty list is a valid answer.`,
+      {
+        label: `audit ${file}`,
+        allowedTools: READ_TOOLS,
+        cwd: process.cwd(),
+        schema: {
+          type: 'object',
+          required: ['findings'],
+          properties: {
+            findings: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['file', 'line', 'summary', 'severity'],
+                properties: {
+                  file: { type: 'string' },
+                  line: { type: 'number' },
+                  summary: { type: 'string' },
+                  severity: { enum: ['low', 'medium', 'high'] },
+                },
+              },
+            },
+          },
+        },
+      },
+    ),
+  (audit: { findings: Finding[] } | null, file: string) => {
+    if (!audit) return [];
+    return parallel(
+      audit.findings.map((finding) => async () => {
+        const verdict = await agent<Verdict>(
+          `A code auditor claims: "${finding.summary}" at ${finding.file}:${finding.line}. Read the surrounding code and try to REFUTE the claim — is the concern actually handled, unreachable, or misread? Default to confirmed=false if uncertain.`,
+          {
+            label: `verify ${file}:${finding.line}`,
+            allowedTools: READ_TOOLS,
+            cwd: process.cwd(),
+            schema: {
+              type: 'object',
+              required: ['confirmed', 'reason'],
+              properties: { confirmed: { type: 'boolean' }, reason: { type: 'string' } },
+            },
+          },
+        );
+        return verdict?.confirmed ? { ...finding, reason: verdict.reason } : null;
+      }),
+    );
+  },
+);
+
+const confirmed = results
+  .filter(Boolean)
+  .flat()
+  .filter(Boolean) as Array<Finding & { reason: string }>;
+
+phase('Report');
+if (confirmed.length === 0) {
+  console.log('No findings survived verification.');
+} else {
+  const order = { high: 0, medium: 1, low: 2 };
+  confirmed.sort((a, b) => order[a.severity] - order[b.severity]);
+  for (const finding of confirmed) {
+    console.log(`\n[${finding.severity}] ${finding.file}:${finding.line}`);
+    console.log(`  ${finding.summary}`);
+    console.log(`  verified: ${finding.reason}`);
+  }
+}
+
+await printSummary();

--- a/examples/workflows/fix-until-pass.ts
+++ b/examples/workflows/fix-until-pass.ts
@@ -1,0 +1,96 @@
+/**
+ * Fix-until-pass workflow: run a check command, fan out fixer agents over
+ * the failures, and repeat until the check passes or two rounds in a row
+ * make no progress.
+ *
+ * Usage:
+ *   bun examples/workflows/fix-until-pass.ts "<check command>"
+ *   bun examples/workflows/fix-until-pass.ts "bunx tsc --noEmit"
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { agent, parallel, phase, log, printSummary } from './runtime.js';
+
+const exec = promisify(execFile);
+
+const checkCommandArg = process.argv[2];
+if (!checkCommandArg) {
+  console.error('Usage: bun fix-until-pass.ts "<check command>"');
+  process.exit(1);
+}
+const checkCommand: string = checkCommandArg;
+
+const MAX_ROUNDS = 5;
+const FIX_TOOLS = ['Read', 'Edit', 'Write', 'Grep', 'Glob', 'Bash'];
+
+async function runCheck(): Promise<{ passed: boolean; output: string }> {
+  try {
+    await exec('sh', ['-c', checkCommand], { maxBuffer: 10 * 1024 * 1024 });
+    return { passed: true, output: '' };
+  } catch (error: any) {
+    const output = `${error.stdout ?? ''}${error.stderr ?? ''}`.trim();
+    return { passed: false, output };
+  }
+}
+
+/** Group failure lines by leading `path:` / `path(` so fixers can run per file. */
+function groupByFile(output: string): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  let current = 'general';
+  for (const line of output.split('\n')) {
+    const match = line.match(/^(\S+\.\w+)[(:]/);
+    if (match?.[1]) current = match[1];
+    if (!groups.has(current)) groups.set(current, []);
+    groups.get(current)!.push(line);
+  }
+  return groups;
+}
+
+let previousFailureSize = Infinity;
+let stalledRounds = 0;
+
+for (let round = 1; round <= MAX_ROUNDS; round++) {
+  phase(`Round ${round}: check`);
+  const check = await runCheck();
+  if (check.passed) {
+    console.log(`\nCheck passed: ${checkCommand}`);
+    await printSummary();
+    process.exit(0);
+  }
+
+  const failureSize = check.output.split('\n').length;
+  log(`${failureSize} lines of failure output`);
+  if (failureSize >= previousFailureSize) {
+    stalledRounds++;
+    if (stalledRounds >= 2) {
+      console.log('\nNo progress for two rounds — stopping.');
+      break;
+    }
+  } else {
+    stalledRounds = 0;
+  }
+  previousFailureSize = failureSize;
+
+  phase(`Round ${round}: fix`);
+  const grouped = groupByFile(check.output);
+  if (grouped.size > 1) grouped.delete('general');
+  const groups = [...grouped.entries()];
+  await parallel(
+    groups.map(([file, lines]) => () =>
+      agent(
+        `The command \`${checkCommand}\` is failing. Fix the failures below with minimal changes — do not refactor unrelated code.\n\n${lines.join('\n').slice(0, 8000)}\n\nWhen done, reply with one sentence describing what you changed.`,
+        {
+          label: `fix ${file}`,
+          allowedTools: FIX_TOOLS,
+          cwd: process.cwd(),
+        },
+      ),
+    ),
+  );
+}
+
+const final = await runCheck();
+console.log(final.passed ? `\nCheck passed: ${checkCommand}` : `\nStill failing after ${MAX_ROUNDS} rounds:\n${final.output.slice(0, 2000)}`);
+await printSummary();

--- a/examples/workflows/migrate-files.ts
+++ b/examples/workflows/migrate-files.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration workflow: transform many files in parallel, each in an isolated
+ * environment, and collect the results deterministically.
+ *
+ * Runs on the cloud backend: every worker session gets its own managed
+ * sandbox with a fresh clone of the repository, so concurrent edits can
+ * never conflict. Workers return a unified diff and the script collects the
+ * patches into ./migrated/, ready for `git apply`.
+ *
+ * Usage:
+ *   LETTA_API_KEY=... bun examples/workflows/migrate-files.ts <owner/repo> <path-prefix> "<transformation>"
+ *   LETTA_API_KEY=... bun examples/workflows/migrate-files.ts letta-ai/letta-agent-sdk examples/bug-fixer "convert console.log color codes to a chalk-style helper"
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { agent, pipeline, phase, log, printSummary, setWorkflowClient, sandboxRepo } from './runtime.js';
+import { LettaAgentClient } from '../../src/index.js';
+
+const [repoArg, pathPrefix, transformation] = process.argv.slice(2);
+if (!repoArg || !pathPrefix || !transformation || !repoArg.includes('/')) {
+  console.error('Usage: bun migrate-files.ts <owner/repo> <path-prefix> "<transformation>"');
+  process.exit(1);
+}
+if (!process.env.LETTA_API_KEY) {
+  console.error('LETTA_API_KEY is required: isolated per-worker sandboxes are a cloud feature.');
+  process.exit(1);
+}
+
+setWorkflowClient(
+  new LettaAgentClient({ backend: 'cloud', apiKey: process.env.LETTA_API_KEY }),
+);
+
+// Every worker gets its own sandbox clone, so parallel edits cannot collide.
+const { sandbox, cwd } = sandboxRepo(repoArg);
+const repo = repoArg.split('/')[1]!;
+const READ_TOOLS = ['Read', 'Grep', 'Glob', 'LS'];
+const MAX_FILES = 10;
+const OUT_DIR = process.env.MIGRATE_OUT ?? 'migrated';
+
+phase('Discover');
+const discovered = await agent<{ files: string[] }>(
+  // Only enumerate here. Deciding what actually needs changing is the
+  // per-file workers' job, and they can do it in parallel.
+  `In the ${repo} repository clone, list every TypeScript file under ${pathPrefix}/ with Glob. Do not read them. Return paths relative to the repository root.`,
+  {
+    label: `scan ${pathPrefix}/`,
+    allowedTools: READ_TOOLS,
+    sandbox,
+    cwd,
+    schema: {
+      type: 'object',
+      required: ['files'],
+      properties: { files: { type: 'array', items: { type: 'string' } } },
+    },
+  },
+);
+
+if (!discovered || discovered.files.length === 0) {
+  console.error('Discovery failed or found no files.');
+  await printSummary();
+  process.exit(1);
+}
+
+let files = discovered.files;
+if (files.length > MAX_FILES) {
+  log(`Migrating first ${MAX_FILES} of ${files.length} files (${files.length - MAX_FILES} dropped).`);
+  files = files.slice(0, MAX_FILES);
+}
+
+phase('Migrate and check');
+// Each file is migrated in its own sandbox clone, then reviewed by an
+// independent checker — no barrier, so checks start as migrations finish.
+const results = await pipeline(
+  files,
+  // The deliverable is a patch, not the rewritten file. Asking a worker to
+  // echo a whole file back through a JSON field silently truncates it; a
+  // truncated patch, by contrast, simply fails to apply.
+  (file: string) =>
+    agent<{ diff: string; changed: boolean }>(
+      `In the ${repo} repository clone, apply this transformation to ${file}: ${transformation}\n\nEdit the file in place. Then run \`git diff -- ${file}\` and return that unified diff exactly as git printed it. Set changed=false if the file needs no changes.`,
+      {
+        label: `migrate ${file}`,
+        allowedTools: [...READ_TOOLS, 'Edit', 'Write', 'Bash'],
+        sandbox,
+        cwd,
+        schema: {
+          type: 'object',
+          required: ['diff', 'changed'],
+          properties: { diff: { type: 'string' }, changed: { type: 'boolean' } },
+        },
+      },
+    ),
+  async (migrated: { diff: string; changed: boolean } | null, file: string) => {
+    if (!migrated || !migrated.changed || !migrated.diff.trim()) return null;
+    const review = await agent<{ ok: boolean; problem: string }>(
+      `In the ${repo} repository clone, read the ORIGINAL ${file}. Then check whether this diff correctly applies "${transformation}" without dropping or breaking existing behavior.\n\n--- diff ---\n${migrated.diff.slice(0, 12000)}`,
+      {
+        label: `check ${file}`,
+        allowedTools: READ_TOOLS,
+        sandbox,
+        cwd,
+        schema: {
+          type: 'object',
+          required: ['ok', 'problem'],
+          properties: { ok: { type: 'boolean' }, problem: { type: 'string' } },
+        },
+      },
+    );
+    return { file, diff: migrated.diff, ok: review?.ok ?? false, problem: review?.problem ?? 'check failed' };
+  },
+);
+
+phase('Collect');
+const migrated = results.filter(Boolean) as Array<{ file: string; diff: string; ok: boolean; problem: string }>;
+for (const entry of migrated) {
+  const target = join(OUT_DIR, `${entry.file}.patch`);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, entry.diff.endsWith('\n') ? entry.diff : `${entry.diff}\n`);
+  console.log(entry.ok ? `  ${entry.file} → ${target}` : `  ${entry.file} → ${target} (check flagged: ${entry.problem})`);
+}
+log(
+  `${migrated.length} patches in ${OUT_DIR}/, ${files.length - migrated.length} unchanged or failed. ` +
+    `Apply with: git apply ${OUT_DIR}/<file>.patch`,
+);
+
+await printSummary();

--- a/examples/workflows/plan-panel.ts
+++ b/examples/workflows/plan-panel.ts
@@ -1,0 +1,167 @@
+/**
+ * Judge-panel workflow: draft an implementation plan from several independent
+ * angles in parallel — each angle on a different model provider — score the
+ * drafts with a judge, and synthesize a final plan from the winner plus the
+ * best ideas of the runners-up.
+ *
+ * Letta agents take any configured provider through a model handle, so the
+ * panel is genuinely diverse: an Anthropic drafter, an OpenAI drafter, and a
+ * Moonshot drafter, judged by a fourth model. Each draft is an independent
+ * agent, so one provider being slow or unavailable costs one draft, not the
+ * run. Override the lineup with PANEL_MODELS (comma-separated handles) and
+ * JUDGE_MODEL.
+ *
+ * With LETTA_API_KEY set, workers run on Letta Cloud, where every provider in
+ * the catalog is reachable. Without it they run on the local backend, which
+ * only reaches providers this machine has credentials for — set PANEL_MODELS
+ * accordingly.
+ *
+ * Usage:
+ *   LETTA_API_KEY=... bun examples/workflows/plan-panel.ts "task description"
+ */
+
+import { agent, parallel, phase, log, printSummary, setWorkflowClient, sandboxRepo } from './runtime.js';
+import { LettaAgentClient } from '../../src/index.js';
+
+const task = process.argv[2];
+if (!task) {
+  console.error('Usage: bun plan-panel.ts "task description"');
+  process.exit(1);
+}
+
+const READ_TOOLS = ['Read', 'Grep', 'Glob', 'LS'];
+
+// On cloud, drafters read the repository from a managed sandbox clone;
+// locally they read the working directory directly.
+const repoArg = process.env.PANEL_REPO;
+const onCloud = Boolean(process.env.LETTA_API_KEY);
+if (onCloud) {
+  setWorkflowClient(new LettaAgentClient({ backend: 'cloud', apiKey: process.env.LETTA_API_KEY }));
+}
+const context = onCloud
+  ? repoArg && repoArg.includes('/')
+    ? { ...sandboxRepo(repoArg), allowedTools: READ_TOOLS }
+    : {}
+  : { allowedTools: READ_TOOLS, cwd: process.cwd() };
+
+// Without repository access, say so — otherwise drafters "explore" an empty
+// sandbox and pad the plan with invented file paths.
+const grounding = context.allowedTools
+  ? 'Explore the repository first and ground the plan in the files you actually find.'
+  : 'You have no repository access. Plan from the description alone and state your assumptions instead of inventing file paths.';
+
+const PANEL_MODELS = (
+  process.env.PANEL_MODELS ??
+  'anthropic/claude-sonnet-5,openai/gpt-5.6-sol,moonshot/kimi-k3'
+).split(',');
+const JUDGE_MODEL = process.env.JUDGE_MODEL ?? 'anthropic/claude-opus-5';
+
+const ANGLES = [
+  {
+    key: 'mvp-first',
+    brief: 'Optimize for the smallest change that ships value. Cut scope aggressively; defer everything deferrable.',
+  },
+  {
+    key: 'risk-first',
+    brief: 'Optimize for de-risking. Identify what could go wrong (migrations, compatibility, edge cases) and sequence the plan to surface failures early.',
+  },
+  {
+    key: 'maintainer-first',
+    brief: 'Optimize for the long-term shape of the codebase. Prefer existing patterns and native mechanisms over new abstractions.',
+  },
+].map((angle, index) => ({ ...angle, model: PANEL_MODELS[index % PANEL_MODELS.length]! }));
+
+phase('Draft');
+log(`panel: ${ANGLES.map((angle) => `${angle.key} on ${angle.model}`).join(', ')}`);
+log(
+  onCloud
+    ? repoArg
+      ? `cloud workers, each with a sandbox clone of ${repoArg}`
+      : 'cloud workers with no repository access (set PANEL_REPO=owner/repo to ground the plans)'
+    : `local workers reading ${process.cwd()}`,
+);
+// Barrier is intentional here: the judge needs all drafts at once.
+const drafts = (
+  await parallel(
+    ANGLES.map((angle) => () =>
+      agent(
+        `Write an implementation plan for the following task. ${grounding}\n\nTask: ${task}\n\nPlanning lens: ${angle.brief}\n\nReturn the plan as markdown: numbered steps, files to touch, and open questions.`,
+        {
+          label: `draft ${angle.key} (${angle.model})`,
+          model: angle.model,
+          ...context,
+        },
+      ),
+    ),
+  )
+).map((plan, index) => ({ angle: ANGLES[index]!.key, model: ANGLES[index]!.model, plan }))
+  .filter((draft) => draft.plan !== null);
+
+if (drafts.length === 0) {
+  console.error(
+    'All drafts failed. Each panel model needs credentials configured in Letta;\n' +
+      'set PANEL_MODELS to handles your deployment can actually reach.',
+  );
+  await printSummary();
+  process.exit(1);
+}
+if (drafts.length < ANGLES.length) {
+  log(`${ANGLES.length - drafts.length} of ${ANGLES.length} drafts failed; judging the rest.`);
+}
+
+phase('Judge');
+const verdict = await agent<{
+  scores: Array<{ angle: string; score: number; strengths: string; weaknesses: string }>;
+  winner: string;
+}>(
+  `Score these ${drafts.length} implementation plans for the task: "${task}". Judge on correctness, scope discipline, and sequencing. Score each 1-10.\n\n${drafts
+    .map((draft) => `## Plan (${draft.angle})\n${draft.plan}`)
+    .join('\n\n')}`,
+  {
+    label: `judge panel (${JUDGE_MODEL})`,
+    model: JUDGE_MODEL,
+    schema: {
+      type: 'object',
+      required: ['scores', 'winner'],
+      properties: {
+        scores: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['angle', 'score', 'strengths', 'weaknesses'],
+            properties: {
+              angle: { type: 'string' },
+              score: { type: 'number' },
+              strengths: { type: 'string' },
+              weaknesses: { type: 'string' },
+            },
+          },
+        },
+        winner: { type: 'string' },
+      },
+    },
+  },
+);
+
+if (!verdict) {
+  console.error('Judging failed; printing raw drafts.');
+  for (const draft of drafts) console.log(`\n## ${draft.angle}\n${draft.plan}`);
+  process.exit(1);
+}
+
+for (const score of verdict.scores) {
+  const model = drafts.find((draft) => draft.angle === score.angle)?.model ?? '?';
+  console.log(`  ${score.angle} (${model}): ${score.score}/10 — ${score.strengths}`);
+}
+
+phase('Synthesize');
+const winning = drafts.find((draft) => draft.angle === verdict.winner) ?? drafts[0]!;
+const others = drafts.filter((draft) => draft !== winning);
+
+const finalPlan = await agent(
+  `Produce the final implementation plan for: "${task}".\n\nStart from the winning plan below. Fold in any runner-up ideas the judge called out as strengths, and address the winner's weaknesses (${verdict.scores.find((s) => s.angle === winning.angle)?.weaknesses ?? 'none noted'}).\n\n## Winning plan (${winning.angle})\n${winning.plan}\n\n${others.map((draft) => `## Runner-up (${draft.angle})\n${draft.plan}`).join('\n\n')}`,
+  { label: 'synthesize', model: JUDGE_MODEL, ...context },
+);
+
+console.log(`\n${finalPlan ?? winning.plan}`);
+await printSummary();

--- a/examples/workflows/plan-panel.ts
+++ b/examples/workflows/plan-panel.ts
@@ -21,6 +21,7 @@
  */
 
 import { agent, parallel, phase, log, printSummary, setWorkflowClient, sandboxRepo } from './runtime.js';
+import type { AgentOptions } from './runtime.js';
 import { LettaAgentClient } from '../../src/index.js';
 
 const task = process.argv[2];
@@ -31,6 +32,24 @@ if (!task) {
 
 const READ_TOOLS = ['Read', 'Grep', 'Glob', 'LS'];
 
+// A planner must not modify the repository it is planning against. There is no
+// read-only permission mode, so say it with the two options that do express it:
+// 'strict' routes every call through canUseTool, which allows reads only. The
+// allowlist above still narrows what a drafter is offered; this is what stops
+// it, whatever it ends up holding.
+const readOnly = {
+  permissionMode: 'strict' as const,
+  // Allow without updatedInput: supplying one *replaces* the tool's arguments,
+  // so returning {} silently strips every call's parameters.
+  canUseTool: (toolName: string) =>
+    READ_TOOLS.includes(toolName)
+      ? { behavior: 'allow' as const }
+      : {
+          behavior: 'deny' as const,
+          message: `${toolName} is not available: a planner may read the repository but never change it.`,
+        },
+};
+
 // On cloud, drafters read the repository from a managed sandbox clone;
 // locally they read the working directory directly.
 const repoArg = process.env.PANEL_REPO;
@@ -38,15 +57,18 @@ const onCloud = Boolean(process.env.LETTA_API_KEY);
 if (onCloud) {
   setWorkflowClient(new LettaAgentClient({ backend: 'cloud', apiKey: process.env.LETTA_API_KEY }));
 }
-const context = onCloud
-  ? repoArg && repoArg.includes('/')
-    ? { ...sandboxRepo(repoArg), allowedTools: READ_TOOLS }
-    : {}
-  : { allowedTools: READ_TOOLS, cwd: process.cwd() };
+const hasRepository = onCloud ? Boolean(repoArg?.includes('/')) : true;
+const context: Partial<AgentOptions> = !hasRepository
+  ? {}
+  : {
+      allowedTools: READ_TOOLS,
+      ...readOnly,
+      ...(onCloud ? sandboxRepo(repoArg!) : { cwd: process.cwd() }),
+    };
 
 // Without repository access, say so — otherwise drafters "explore" an empty
 // sandbox and pad the plan with invented file paths.
-const grounding = context.allowedTools
+const grounding = hasRepository
   ? 'Explore the repository first and ground the plan in the files you actually find.'
   : 'You have no repository access. Plan from the description alone and state your assumptions instead of inventing file paths.';
 

--- a/examples/workflows/research-sources.ts
+++ b/examples/workflows/research-sources.ts
@@ -1,0 +1,122 @@
+/**
+ * Research workflow: fan out searchers across independent angles, dedupe the
+ * claims they surface, cross-check each claim with a verifier, and report
+ * only claims that survive with their sources.
+ *
+ * Workers use Letta's server-side web_search and fetch_webpage tools,
+ * attached at agent creation via baseTools. Those tools are executed by the
+ * Letta server, so this workflow runs on the cloud backend — the local
+ * app-server backend attaches no server-side tools.
+ *
+ * Usage:
+ *   LETTA_API_KEY=... bun examples/workflows/research-sources.ts "research question"
+ */
+
+import { agent, parallel, phase, log, printSummary, setWorkflowClient } from './runtime.js';
+import { LettaAgentClient } from '../../src/index.js';
+
+const question = process.argv[2];
+if (!question) {
+  console.error('Usage: bun research-sources.ts "research question"');
+  process.exit(1);
+}
+if (!process.env.LETTA_API_KEY) {
+  console.error('LETTA_API_KEY is required: web_search is a server-side tool on the cloud backend.');
+  process.exit(1);
+}
+
+setWorkflowClient(
+  new LettaAgentClient({ backend: 'cloud', apiKey: process.env.LETTA_API_KEY }),
+);
+
+const WEB_TOOLS = ['web_search', 'fetch_webpage'];
+
+const SEARCH_ANGLES = [
+  'official documentation and primary sources',
+  'recent news, changelogs, and release notes',
+  'critical takes, known problems, and counterexamples',
+];
+
+interface Claim {
+  claim: string;
+  source: string;
+}
+
+phase('Search');
+const found = await parallel(
+  SEARCH_ANGLES.map((searchAngle) => () =>
+    agent<{ claims: Claim[] }>(
+      `Research this question, focusing on ${searchAngle}: ${question}\n\nSearch the web and read the most relevant pages. Report 3-6 specific factual claims, each with the URL it came from.`,
+      {
+        label: `search: ${searchAngle.split(',')[0]}`,
+        baseTools: WEB_TOOLS,
+        schema: {
+          type: 'object',
+          required: ['claims'],
+          properties: {
+            claims: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['claim', 'source'],
+                properties: { claim: { type: 'string' }, source: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    ),
+  ),
+);
+
+const claims = found.filter(Boolean).flatMap((result) => result!.claims);
+// Rough dedupe: drop claims whose normalized text repeats.
+const seen = new Set<string>();
+const unique = claims.filter((entry) => {
+  const key = entry.claim.toLowerCase().replace(/\W+/g, ' ').trim();
+  if (seen.has(key)) return false;
+  seen.add(key);
+  return true;
+});
+log(`${claims.length} claims found, ${unique.length} after dedupe`);
+
+phase('Verify');
+const verified = await parallel(
+  unique.map((entry) => async () => {
+    const verdict = await agent<{ verdict: 'supported' | 'refuted' | 'unverifiable'; note: string }>(
+      `Cross-check this claim against sources OTHER than ${entry.source}:\n\n"${entry.claim}"\n\nSearch independently. Report supported only if a second source agrees; refuted if a credible source contradicts it; unverifiable otherwise.`,
+      {
+        label: `verify: ${entry.claim.slice(0, 50)}`,
+        baseTools: WEB_TOOLS,
+        schema: {
+          type: 'object',
+          required: ['verdict', 'note'],
+          properties: {
+            verdict: { enum: ['supported', 'refuted', 'unverifiable'] },
+            note: { type: 'string' },
+          },
+        },
+      },
+    );
+    return verdict ? { ...entry, ...verdict } : null;
+  }),
+);
+
+phase('Report');
+const results = verified.filter(Boolean) as Array<Claim & { verdict: string; note: string }>;
+const supported = results.filter((entry) => entry.verdict === 'supported');
+const unverifiable = results.filter((entry) => entry.verdict === 'unverifiable');
+
+console.log(`\n# ${question}\n`);
+for (const entry of supported) {
+  console.log(`- ${entry.claim}\n  source: ${entry.source}\n  cross-check: ${entry.note}`);
+}
+if (unverifiable.length > 0) {
+  console.log(`\nUnverified (single-source):`);
+  for (const entry of unverifiable) {
+    console.log(`- ${entry.claim} (${entry.source})`);
+  }
+}
+log(`${supported.length} supported, ${unverifiable.length} unverifiable, ${results.filter((entry) => entry.verdict === 'refuted').length} refuted`);
+
+await printSummary();

--- a/examples/workflows/runtime.ts
+++ b/examples/workflows/runtime.ts
@@ -15,8 +15,10 @@
 
 import { LettaAgentClient } from '../../src/index.js';
 import type {
+  CanUseToolCallback,
   LettaCodeClientSessionOptions,
   LettaCodeCloudSandboxOptions,
+  PermissionMode,
 } from '../../src/index.js';
 
 const DEFAULT_MODEL = process.env.LETTA_WORKFLOW_MODEL ?? 'haiku';
@@ -43,6 +45,10 @@ export interface AgentOptions {
   /** Per-worker managed sandbox (cloud backend only). */
   sandbox?: LettaCodeCloudSandboxOptions;
   cwd?: string;
+  /** Defaults to 'unrestricted'. Use 'strict' to route every call through canUseTool. */
+  permissionMode?: PermissionMode;
+  /** Approval callback, required for a stage that runs under 'strict'. */
+  canUseTool?: CanUseToolCallback;
 }
 
 export const stats = { agents: 0, failures: 0, costUsd: 0 };
@@ -148,7 +154,8 @@ export async function agent<T = string>(
       // instead of the harness default plus an allowlist on top of it.
       toolset: { base: 'none', include: tools },
       allowedTools: tools,
-      permissionMode: 'unrestricted',
+      permissionMode: opts.permissionMode ?? 'unrestricted',
+      canUseTool: opts.canUseTool,
       cwd: opts.cwd,
       sandbox: opts.sandbox,
     };

--- a/examples/workflows/runtime.ts
+++ b/examples/workflows/runtime.ts
@@ -1,0 +1,254 @@
+/**
+ * Dynamic workflow runtime
+ *
+ * A small orchestration layer over the Letta Agent SDK that mirrors the
+ * Claude Code dynamic-workflow contract (https://code.claude.com/docs/en/workflows):
+ *
+ * - agent(task, opts)          spawn one worker agent, resolve to its result
+ * - parallel(thunks)           run tasks concurrently, barrier until all settle
+ * - pipeline(items, ...stages) run each item through stages independently
+ * - phase(title) / log(msg)    progress narration
+ *
+ * agent() resolves to null on failure instead of rejecting, so fan-outs
+ * degrade per-item: filter results with .filter(Boolean).
+ */
+
+import { LettaAgentClient } from '../../src/index.js';
+import type {
+  LettaCodeClientSessionOptions,
+  LettaCodeCloudSandboxOptions,
+} from '../../src/index.js';
+
+const DEFAULT_MODEL = process.env.LETTA_WORKFLOW_MODEL ?? 'haiku';
+const MAX_CONCURRENT = Number(process.env.LETTA_WORKFLOW_CONCURRENCY ?? 4);
+
+const COLORS = {
+  phase: '\x1b[1m\x1b[35m',
+  ok: '\x1b[32m',
+  fail: '\x1b[31m',
+  dim: '\x1b[90m',
+  reset: '\x1b[0m',
+};
+
+export interface AgentOptions {
+  /** Display label for progress lines (defaults to a prompt prefix). */
+  label?: string;
+  /** JSON schema for structured output; agent() returns the parsed value. */
+  schema?: object;
+  model?: string;
+  /** Client-side tool allowlist for the worker session. */
+  allowedTools?: string[];
+  /** Server-side tools attached to the worker agent (e.g. web_search). */
+  baseTools?: string[];
+  /** Per-worker managed sandbox (cloud backend only). */
+  sandbox?: LettaCodeCloudSandboxOptions;
+  cwd?: string;
+}
+
+export const stats = { agents: 0, failures: 0, costUsd: 0 };
+
+class Semaphore {
+  private queue: Array<() => void> = [];
+  constructor(private available: number) {}
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.queue.push(resolve));
+  }
+  release(): void {
+    const next = this.queue.shift();
+    if (next) next();
+    else this.available++;
+  }
+}
+
+const slots = new Semaphore(MAX_CONCURRENT);
+const pendingCleanup: Array<Promise<void>> = [];
+
+let workflowClient = new LettaAgentClient();
+
+/** Route workers through a different client, e.g. cloud with managed sandboxes. */
+export function setWorkflowClient(client: LettaAgentClient): void {
+  workflowClient = client;
+}
+
+/**
+ * Sandbox + cwd for a cloud worker that should read a GitHub repository.
+ *
+ * Managed sandboxes clone into /root/workspace/<repo>. Pointing cwd there
+ * matters for more than convenience: a worker left in /root has the agent
+ * state tree (/root/.letta/agents) below it, and the harness's cross-agent
+ * memory guard denies every recursive path tool — LS, Glob, Grep — from a
+ * directory that contains it.
+ */
+export function sandboxRepo(ref: string): { sandbox: LettaCodeCloudSandboxOptions; cwd: string } {
+  const [owner, repo] = ref.split('/');
+  if (!owner || !repo) throw new Error(`Expected owner/repo, got "${ref}"`);
+  return {
+    sandbox: { githubRepositories: [{ owner, repo }] },
+    cwd: `/root/workspace/${repo}`,
+  };
+}
+
+let currentPhase = '';
+
+export function phase(title: string): void {
+  currentPhase = title;
+  console.log(`\n${COLORS.phase}── ${title} ──${COLORS.reset}`);
+}
+
+export function log(message: string): void {
+  console.log(`${COLORS.dim}${message}${COLORS.reset}`);
+}
+
+/** Pull a JSON value out of a model reply that may include fences or prose. */
+function extractJson(text: string): unknown {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = (fenced?.[1] ?? text).trim();
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    const start = candidate.search(/[[{]/);
+    const end = Math.max(candidate.lastIndexOf('}'), candidate.lastIndexOf(']'));
+    if (start === -1 || end <= start) throw new Error('no JSON in reply');
+    return JSON.parse(candidate.slice(start, end + 1));
+  }
+}
+
+/**
+ * Spawn one worker agent for a task and resolve to its final output.
+ *
+ * Each call creates an ephemeral hidden agent (no memfs, no server tools),
+ * runs the task as a one-shot conversation, and deletes the agent. With
+ * `schema`, the reply is parsed as JSON (one reformat retry) and the parsed
+ * value is returned; otherwise the raw final text is returned.
+ */
+export async function agent<T = string>(
+  task: string,
+  opts: AgentOptions = {},
+): Promise<T | null> {
+  const label = opts.label ?? task.replace(/\s+/g, ' ').slice(0, 60);
+  await slots.acquire();
+  const started = Date.now();
+  let agentId: string | null = null;
+  try {
+    agentId = await workflowClient.createAgent({
+      model: opts.model ?? DEFAULT_MODEL,
+      memfs: false,
+      hidden: true,
+      baseTools: opts.baseTools ?? [],
+    });
+
+    const tools = opts.allowedTools ?? [];
+    const sessionOptions: LettaCodeClientSessionOptions = {
+      model: opts.model ?? DEFAULT_MODEL,
+      // base 'none' keeps a worker's toolset to exactly what the stage names,
+      // instead of the harness default plus an allowlist on top of it.
+      toolset: { base: 'none', include: tools },
+      allowedTools: tools,
+      permissionMode: 'unrestricted',
+      cwd: opts.cwd,
+      sandbox: opts.sandbox,
+    };
+
+    const instruction = opts.schema
+      ? `${task}\n\nYour final message is parsed by a script, not read by a human. Respond with ONLY a JSON instance conforming to this JSON Schema — the data itself, no markdown fences, no prose, and no schema keywords like "type", "properties", or "required":\n${JSON.stringify(opts.schema)}`
+      : `${task}\n\nYour final message is returned to an orchestrating script as a raw value. Return only the requested output, no preamble.`;
+
+    let result = await workflowClient.prompt(instruction, agentId, sessionOptions);
+    stats.agents++;
+    stats.costUsd += result.totalCostUsd ?? 0;
+
+    // Turns fail transiently often enough that one retry is worth it: in a
+    // fan-out, a single unlucky worker otherwise drops a whole file or claim.
+    if (!result.success && result.recoverable !== false) {
+      result = await workflowClient.prompt(instruction, agentId, sessionOptions);
+      stats.costUsd += result.totalCostUsd ?? 0;
+    }
+
+    if (!result.success || !result.result) {
+      stats.failures++;
+      const detail = [result.errorCode ?? 'no output', result.error ?? result.errorDetail]
+        .filter(Boolean)
+        .join(': ');
+      console.log(`${COLORS.fail}✗${COLORS.reset} ${label} ${COLORS.dim}(${detail})${COLORS.reset}`);
+      return null;
+    }
+
+    let value: unknown = result.result.trim();
+    if (opts.schema) {
+      try {
+        value = extractJson(result.result);
+      } catch {
+        result = await workflowClient.prompt(
+          `Reformat the following as ONLY a JSON value matching this schema, nothing else:\n${JSON.stringify(opts.schema)}\n\n${result.result}`,
+          agentId,
+          sessionOptions,
+        );
+        stats.costUsd += result.totalCostUsd ?? 0;
+        try {
+          value = extractJson(result.result ?? '');
+        } catch {
+          stats.failures++;
+          console.log(`${COLORS.fail}✗${COLORS.reset} ${label} ${COLORS.dim}(unparseable reply)${COLORS.reset}`);
+          return null;
+        }
+      }
+    }
+
+    const seconds = ((Date.now() - started) / 1000).toFixed(1);
+    console.log(`${COLORS.ok}✓${COLORS.reset} ${currentPhase ? `[${currentPhase}] ` : ''}${label} ${COLORS.dim}(${seconds}s)${COLORS.reset}`);
+    return value as T;
+  } catch (error) {
+    stats.failures++;
+    console.log(`${COLORS.fail}✗${COLORS.reset} ${label} ${COLORS.dim}(${error instanceof Error ? error.message : String(error)})${COLORS.reset}`);
+    return null;
+  } finally {
+    slots.release();
+    if (agentId) {
+      pendingCleanup.push(workflowClient.agents.delete(agentId).catch(() => {}));
+    }
+  }
+}
+
+/**
+ * Run tasks concurrently and barrier until all settle. A thunk that throws
+ * resolves to null in the result array; the call itself never rejects.
+ */
+export async function parallel<T>(thunks: Array<() => Promise<T>>): Promise<Array<T | null>> {
+  return Promise.all(thunks.map((thunk) => thunk().catch(() => null)));
+}
+
+type Stage = (prev: any, item: any, index: number) => any;
+
+/**
+ * Run each item through all stages independently — no barrier between
+ * stages, so item A can be in stage 2 while item B is still in stage 1.
+ * A stage that throws drops that item to null and skips its remaining stages.
+ */
+export async function pipeline(items: any[], ...stages: Stage[]): Promise<any[]> {
+  return Promise.all(
+    items.map(async (item, index) => {
+      let value: any = item;
+      for (const stage of stages) {
+        try {
+          value = await stage(value, item, index);
+        } catch {
+          return null;
+        }
+      }
+      return value;
+    }),
+  );
+}
+
+/** Print run totals and wait for worker-agent deletions. Call once at the end of a workflow script. */
+export async function printSummary(): Promise<void> {
+  await Promise.allSettled(pendingCleanup);
+  const cost = stats.costUsd > 0 ? `, $${stats.costUsd.toFixed(4)}` : '';
+  console.log(
+    `\n${COLORS.dim}${stats.agents} agents, ${stats.failures} failures${cost}${COLORS.reset}`,
+  );
+}


### PR DESCRIPTION
Script-orchestrated multi-agent workflows on the Agent SDK, in the shape of Claude Code dynamic workflows: the script holds the loop, the branching, and the intermediate results; agents do the reading, editing, and searching.

`runtime.ts` provides `agent()`, `parallel()`, `pipeline()`, `phase()`, `log()`, plus `setWorkflowClient()` and `sandboxRepo()`. Workers are hidden agents created without memfs, run as one-shot conversations, and deleted when they finish.

Five examples:

- `audit-files` — one auditor per file, each finding adversarially verified
- `fix-until-pass` — run a check, fix failures in parallel, stop when it passes or stalls
- `plan-panel` — three drafts on three providers, judged, then synthesized
- `research-sources` — searchers with server-side `web_search`, every claim cross-checked
- `migrate-files` — per-worker sandbox clones, collecting reviewed patches

All five were run end to end. `plan-panel`, `research-sources`, and `migrate-files` need the cloud backend: server-side tools and isolated per-worker sandboxes are cloud features, and the local backend reaches only the providers the machine holds credentials for.
