### PR TITLE
fix: recover idle Cloud status sessions

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -357,12 +357,44 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     );
     this.connectionId = connection.connectionId;
 
+    const options = this.currentOptions();
+    this.mcpBridge = await connectMcpServers(
+      "mcpServers" in options ? options.mcpServers : undefined,
+      {
+        cwd: options.cwd,
+        reservedToolNames: this.externalTools.keys(),
+      },
+    );
+    for (const tool of this.mcpBridge.tools) {
+      this.externalTools.set(tool.name, tool);
+    }
+
+    try {
+      return await this.openCloudTransport(
+        resolved.runtime,
+        connection.connectionId,
+      );
+    } catch (error) {
+      await this.closeMcpBridge();
+      await this.cleanupManagedSandbox();
+      await this.cleanupSessionRepositories(
+        resolved.runtime.agent_id,
+        resolved.runtime.conversation_id,
+      );
+      throw error;
+    }
+  }
+
+  private async openCloudTransport(
+    runtime: RuntimeScope,
+    connectionId: string,
+  ): Promise<RuntimeSessionInit> {
     const apiKey = getCloudApiKey(this.cloudOptions);
     const url = buildCloudStatusWebSocketUrl({
       apiBaseUrl: this.cloudOptions.apiBaseUrl,
-      connectionId: connection.connectionId,
-      agentId: resolved.runtime.agent_id,
-      conversationId: resolved.runtime.conversation_id,
+      connectionId,
+      agentId: runtime.agent_id,
+      conversationId: runtime.conversation_id,
       apiKey,
       authMode: this.cloudOptions.webSocketAuth ?? "header",
     });
@@ -376,40 +408,21 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
           : {}),
         pingIntervalMs:
           this.cloudOptions.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS,
-        runtime: resolved.runtime,
+        runtime,
       }),
       requestTimeoutMs: this.cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
     }));
     const options = this.currentOptions();
-    this.mcpBridge = await connectMcpServers(
-      "mcpServers" in options ? options.mcpServers : undefined,
-      {
-        cwd: options.cwd,
-        reservedToolNames: this.externalTools.keys(),
-      },
-    );
-    for (const tool of this.mcpBridge.tools) {
-      this.externalTools.set(tool.name, tool);
-    }
-    this.removeControlRequestHandler = registerAppServerControlRequestHandler({
-      client,
-      getRuntime: () => this.runtime,
-      getOptions: () => this.currentOptions(),
-    });
-    if (this.externalTools.size > 0) {
-      this.removeExternalToolHandler = client.onExternalToolCall(
-        createExternalToolCallHandler(this.externalTools),
-      );
-    }
+    this.installTransportHandlers(client);
 
     try {
       await client.connect();
-      const response = await this.startCloudRuntime(client, resolved.runtime);
+      const response = await this.startCloudRuntime(client, runtime);
       if (!response.success || !response.runtime) {
         throw new Error(response.error ?? "Failed to start Cloud status runtime");
       }
 
-      this.watchTransportDisconnect(client);
+      this.watchTransportDisconnect(client, { recoverWhenIdle: true });
 
       const tools = agentToolNames(response.agent);
       const skillSources = options.skillSources;
@@ -439,19 +452,62 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         ...(skillSources !== undefined ? { skillSources: [...skillSources] } : {}),
       };
     } catch (error) {
-      this.removeExternalToolHandler?.();
-      this.removeExternalToolHandler = null;
-      this.removeControlRequestHandler?.();
-      this.removeControlRequestHandler = null;
-      await this.closeMcpBridge();
+      this.cleanupTransportHandlers();
       client.close();
-      await this.cleanupManagedSandbox();
-      await this.cleanupSessionRepositories(
-        resolved.runtime.agent_id,
-        resolved.runtime.conversation_id,
-      );
       throw error;
     }
+  }
+
+  private installTransportHandlers(client: AppServerClient): void {
+    this.cleanupTransportHandlers();
+    this.removeControlRequestHandler = registerAppServerControlRequestHandler({
+      client,
+      getRuntime: () => this.runtime,
+      getOptions: () => this.currentOptions(),
+    });
+    if (this.externalTools.size > 0) {
+      this.removeExternalToolHandler = client.onExternalToolCall(
+        createExternalToolCallHandler(this.externalTools),
+      );
+    }
+  }
+
+  private cleanupTransportHandlers(): void {
+    this.removeExternalToolHandler?.();
+    this.removeExternalToolHandler = null;
+    this.removeControlRequestHandler?.();
+    this.removeControlRequestHandler = null;
+  }
+
+  protected override async recoverIdleTransport(
+    runtime: RuntimeScope,
+  ): Promise<RuntimeSessionInit> {
+    const connection = await this.resolveRecoveryConnection(runtime);
+    this.connectionId = connection.connectionId;
+    return this.openCloudTransport(runtime, connection.connectionId);
+  }
+
+  private async resolveRecoveryConnection(
+    runtime: RuntimeScope,
+  ): Promise<ResolvedCloudConnection> {
+    const sandbox = this.managedSandbox;
+    if (sandbox) {
+      await this.refreshManagedSandbox(sandbox);
+      return this.waitForManagedSandboxConnection(sandbox);
+    }
+    const environment = this.effectiveEnvironment();
+    if (!environment) {
+      throw new Error("Cloud idle transport recovery lost its execution target");
+    }
+    return this.resolveExplicitConnection(environment);
+  }
+
+  protected override onIdleTransportDisconnect(): void {
+    this.cleanupTransportHandlers();
+  }
+
+  protected override onRecoveredTransportDiscarded(): void {
+    this.cleanupTransportHandlers();
   }
 
   private async startCloudRuntime(
@@ -501,10 +557,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   protected override onCoreClose(): void {
-    this.removeExternalToolHandler?.();
-    this.removeExternalToolHandler = null;
-    this.removeControlRequestHandler?.();
-    this.removeControlRequestHandler = null;
+    this.cleanupTransportHandlers();
     this.mcpCleanup = this.closeMcpBridge();
     void this.cleanupManagedSandbox();
     if (this.runtime?.agent_id) {

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -78,6 +78,9 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   private initializePromise: Promise<SDKInitMessage> | null = null;
   private removeMessageHandler: (() => void) | null = null;
   private detachTransportDisconnect: (() => void) | null = null;
+  private idleTransportDisconnected = false;
+  private transportRecoveryPromise: Promise<void> | null = null;
+  private transportDisconnectGeneration = 0;
   private readonly turns: RemoteTurnCoordinator;
   private toolNames: string[] | undefined;
   private deviceStatusListeners = new Set<(status: SessionDeviceStatus) => void>();
@@ -207,18 +210,25 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   }
 
   async send(message: SendMessage): Promise<void> {
+    if (this.closed) throw new Error("Session is closed");
     if (!this.initialized) {
       await this.initialize();
     }
+    await this.recoverIdleTransportIfNeeded();
     if (!this.controller || !this.runtime) {
       throw new Error("Session is not initialized");
     }
 
     await this.beforeTurn();
 
-    const turn = this.turns.trackSentTurn(this.runtime);
+    const controller = this.controller;
+    const runtime = this.runtime;
+    if (!controller || !runtime) {
+      throw new Error("Session transport disconnected before the turn was sent");
+    }
+    const turn = this.turns.trackSentTurn(runtime);
     try {
-      this.controller.sendTurnMessage(this.runtime, message, {
+      controller.sendTurnMessage(runtime, message, {
         clientMessageId: turn.clientMessageId,
       });
     } catch (error) {
@@ -556,6 +566,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     this.deviceStatusListeners.clear();
     this.controller?.close();
     this.controller = null;
+    this.idleTransportDisconnected = false;
     this.onCoreClose();
   }
 
@@ -625,32 +636,92 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   protected abstract initializeRuntimeController(): Promise<RuntimeSessionInit>;
 
   /**
-   * Fail the session when its transport drops unexpectedly.
-   *
-   * Without this an in-flight turn parks forever: nextMessage() only settles
-   * through the coordinator, and the socket's own pending-request rejection
-   * covers request/response commands, not streaming turns.
-   *
-   * The session is not revived — the runtime lived on the dead socket. The
-   * caller observes the error and rebuilds via resumeSession().
-   *
-   * Subclasses call this only once their runtime is live: a drop before that
-   * already surfaces as a rejected connect or runtime-start, and failing the
-   * session there would defeat initialize()'s retry path. Explicit closes do
-   * not notify, so this fires for faults only. Detaching stays here so every
-   * teardown path — clean close and failed initialize alike — covers it.
+   * Active turns fail because the input may have reached the listener. Cloud
+   * sessions may recover an idle connection before the next turn is tracked.
    */
-  protected watchTransportDisconnect(client: {
-    onDisconnect(handler: () => void): () => void;
-  }): void {
+  protected watchTransportDisconnect(
+    client: { onDisconnect(handler: () => void): () => void },
+    options: { recoverWhenIdle?: boolean } = {},
+  ): void {
     this.detachTransportDisconnect?.();
     this.detachTransportDisconnect = client.onDisconnect(() => {
       if (this.closed) return;
+      this.transportDisconnectGeneration += 1;
+      if (options.recoverWhenIdle && !this.turns.hasInFlightTurn()) {
+        this.detachTransportDisconnect?.();
+        this.detachTransportDisconnect = null;
+        this.removeMessageHandler?.();
+        this.removeMessageHandler = null;
+        this.controller?.close();
+        this.controller = null;
+        const error = new Error(`${this.label} connection closed before send`);
+        for (const cancel of [...this.deviceStatusRefreshCancels]) cancel(error);
+        this.deviceStatusRefreshCancels.clear();
+        this.onIdleTransportDisconnect();
+        this.idleTransportDisconnected = true;
+        return;
+      }
       this.turns.closeWithError(
         `The ${this.label} connection closed unexpectedly; resume the conversation to continue.`,
       );
       this.close();
     });
+  }
+
+  private async recoverIdleTransportIfNeeded(): Promise<void> {
+    if (!this.idleTransportDisconnected) return;
+    if (this.transportRecoveryPromise) {
+      await this.transportRecoveryPromise;
+      return;
+    }
+    const runtime = this.runtime;
+    if (!runtime) throw new Error("Session transport disconnected without a runtime");
+    const generation = this.transportDisconnectGeneration;
+    const recovery = this.recoverIdleTransport(runtime)
+      .then(async (init) => {
+        if (this.closed || generation !== this.transportDisconnectGeneration) {
+          init.controller.close();
+          this.onRecoveredTransportDiscarded();
+          throw new Error(`${this.label} connection closed during recovery`);
+        }
+        if (
+          init.runtime.agent_id !== runtime.agent_id ||
+          init.runtime.conversation_id !== runtime.conversation_id
+        ) {
+          init.controller.close();
+          this.onRecoveredTransportDiscarded();
+          throw new Error(`${this.label} transport recovered a different runtime`);
+        }
+        this.controller = init.controller;
+        this.runtime = init.runtime;
+        this._modelSettings = init.modelSettings ?? this._modelSettings;
+        if (typeof init.model === "string" && init.model) this._model = init.model;
+        if (init.tools !== undefined) this.toolNames = init.tools;
+        this.removeMessageHandler = this.controller.onMessage((message) => {
+          if (this.runtime) this.turns.handleProtocolMessage(message, this.runtime);
+        });
+        this.idleTransportDisconnected = false;
+        await this.afterRuntimeInitialized();
+      })
+      .finally(() => {
+        if (this.transportRecoveryPromise === recovery) this.transportRecoveryPromise = null;
+      });
+    this.transportRecoveryPromise = recovery;
+    await recovery;
+  }
+
+  protected async recoverIdleTransport(
+    _runtime: RuntimeScope,
+  ): Promise<RuntimeSessionInit> {
+    throw new Error(`${this.label} sessions do not support idle transport recovery`);
+  }
+
+  protected onIdleTransportDisconnect(): void {
+    // Optional hook for transport-specific handler cleanup before recovery.
+  }
+
+  protected onRecoveredTransportDiscarded(): void {
+    // Optional hook when a recovery finishes after the session closed or dropped again.
   }
 
   protected async afterRuntimeInitialized(): Promise<void> {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -255,7 +255,8 @@ class FakeCloudSocket {
     | "approval"
     | "terminal_error"
     | "stale_idle_then_error"
-    | "duplicate_idempotency" = "normal";
+    | "duplicate_idempotency"
+    | "hang" = "normal";
   static syncSucceeds = true;
   static deviceStatusOnSync = false;
   readyState = 0;
@@ -274,7 +275,10 @@ class FakeCloudSocket {
   }
 
   static socket(channel: "control" | "stream"): FakeCloudSocket | undefined {
-    return FakeCloudSocket.instances.find((socket) => socket.channel === channel);
+    const matching = FakeCloudSocket.instances
+      .filter((socket) => socket.channel === channel)
+      .reverse();
+    return matching.find((socket) => socket.readyState !== 3) ?? matching[0];
   }
 
   static allSent(): Array<Record<string, unknown>> {
@@ -424,6 +428,10 @@ class FakeCloudSocket {
     if (command.type !== "input") return;
     const runtime = command.runtime;
     const payload = command.payload as Record<string, unknown> | undefined;
+
+    if (payload?.kind === "create_message" && FakeCloudSocket.scenario === "hang") {
+      return;
+    }
 
     if (payload?.kind === "create_message" && FakeCloudSocket.scenario === "approval") {
       this.serverMessageTo("control", {
@@ -1427,6 +1435,107 @@ describe("CloudEnvironmentSession", () => {
     expect(streamSocket.sent).toContainEqual({ type: "ack", seq: 102 });
 
     session.close();
+  });
+
+  test("recovers an idle Cloud status transport before sending one input", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("agent-1");
+    try {
+      await asAdvanced(session).initialize();
+      expect(FakeCloudSocket.instances).toHaveLength(2);
+
+      // The runtime is live, but no input has been tracked or sent. A Cloud
+      // rollout closes one status socket and the paired transport follows.
+      FakeCloudSocket.socket("stream")!.close();
+      await Promise.resolve();
+
+      const result = await asAdvanced(session).sendAndWaitForResult("hello once");
+      expect(result).toMatchObject({
+        success: true,
+        result: "hello from cloud",
+      });
+
+      expect(FakeCloudSocket.instances).toHaveLength(4);
+      expect(
+        FakeCloudSocket.allSent().filter((command) => command.type === "runtime_start"),
+      ).toHaveLength(2);
+      const inputs = FakeCloudSocket.allSent().filter((command) => {
+        const payload = command.payload as { kind?: string } | undefined;
+        return command.type === "input" && payload?.kind === "create_message";
+      });
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0]).toMatchObject({
+        payload: {
+          messages: [expect.objectContaining({ content: "hello once" })],
+        },
+      });
+      expect(
+        requests.filter((request) =>
+          request.method === "POST" &&
+          new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes"
+        ),
+      ).toHaveLength(1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("keeps a Cloud transport drop terminal after input may have dispatched", async () => {
+    resetFakeCloud();
+    FakeCloudSocket.scenario = "hang";
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      environment: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("agent-1");
+    try {
+      await asAdvanced(session).initialize();
+      await session.send("possibly dispatched");
+      const messages: unknown[] = [];
+      const drained = (async () => {
+        for await (const message of session.stream()) messages.push(message);
+      })();
+      await Promise.resolve();
+
+      FakeCloudSocket.socket("stream")!.close();
+      await drained;
+
+      expect(messages[0]).toMatchObject({
+        type: "error",
+        stopReason: "error",
+      });
+      expect(messages.at(-1)).toMatchObject({
+        type: "result",
+        success: false,
+        errorCode: "error",
+      });
+      await expect(session.send("do not replay")).rejects.toThrow("Session is closed");
+      const inputs = FakeCloudSocket.allSent().filter((command) => {
+        const payload = command.payload as { kind?: string } | undefined;
+        return command.type === "input" && payload?.kind === "create_message";
+      });
+      expect(inputs).toHaveLength(1);
+    } finally {
+      FakeCloudSocket.scenario = "normal";
+      session.close();
+    }
   });
 
   test("attaches to an explicit environment without creating a sandbox", async () => {


### PR DESCRIPTION
## Summary

Cloud sessions currently close permanently when the status WebSocket drops after `runtime_start`, even when no user input was sent. A short relay restart can therefore reject the first `send()` although the listener has already reconnected.

This change keeps such sessions recoverable while idle. The next `send()` refreshes the existing managed sandbox or selected computer, opens a new status transport, and starts the same runtime before it tracks or sends the input.

## Safety boundary

- Input is never replayed.
- If a turn is already tracked, the disconnect remains terminal because the listener may have accepted the input.
- Local and remote App Server sessions keep their existing disconnect behavior.
- Managed sandbox recovery reuses the existing sandbox instead of creating another one.

## Validation

- New regression fails on `main` with `Session is not initialized` and passes on this branch.
- Idle recovery sends one input after opening the replacement transport.
- Active-turn disconnect still emits an error and failed result, then rejects another send.
- Live Cloud transport check: closed the stream socket after runtime startup, observed one replacement socket pair, and observed exactly one input on the recovered transport. The target test organization had insufficient credits for model completion, so this check proves transport recovery and single dispatch, not a successful model response.
- `bun run check`
- `bun test` — 215 passed, 11 live tests skipped
- `bun run build`
- `git diff --check`