### PR TITLE
feat: replace prompt with query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,33 +56,21 @@ An agent is the persistent entity with memory. A conversation is a thread on tha
 
 ## Query
 
-`query()` provides the same `query({ prompt, options })` call shape as the
-Claude Agent SDK and streams `SDKMessage` values. Letta additionally accepts an
-optional `agentId`:
+`query()` runs a prompt and streams `SDKMessage` values:
 
 ```ts
-for await (const message of client.query({
+const run = client.query({
   prompt: "Review the current changes.",
-  agentId,
-  options: {
-    allowedTools: ["Read", "Glob", "Grep"],
-  },
-})) {
+  options: { model: "openai/gpt-5.6-luna" },
+});
+for await (const message of run) {
   if (message.type === "assistant") console.log(message.content);
-  if (message.type === "result") console.log(message.success, message.result);
 }
 ```
 
-When `agentId` is supplied, the query creates a new conversation on that
-persistent agent. Omit `agentId` and pass `options.model` to create a hidden
-non-MemFS agent with that model and force the conversation into stateless mode.
-The query does not load or change agent memory. Model selection is unavailable
-with `agentId` because session model updates would mutate the persistent agent.
-
-A prompt can also be an `AsyncIterable<SendMessage>`. The SDK consumes that
-iterable concurrently with the output stream, so additional messages can be
-injected or queued while the current turn is running. Long-running queries can
-be controlled directly with `await query.interrupt()` and `query.close()`.
+Pass `agentId` to create a new conversation on an existing agent. Without one,
+`query()` creates a hidden stateless agent. Async prompt iterables support
+mid-turn injection; long-running queries expose `interrupt()` and `close()`.
 
 Pass `stateless: true` when a session should use an existing agent without
 loading or changing its MemFS:
@@ -252,9 +240,9 @@ await using session = client.createSession(agentId, {
 ```
 
 Connections start concurrently during session initialization. A failed server
-is skipped without dropping healthy servers. OAuth is host-managed, matching
-the Claude Agent SDK: complete OAuth in your application and provide the access
-token through `headers`. The SDK does not open an interactive browser flow.
+is skipped without dropping healthy servers. OAuth is host-managed: complete
+OAuth in your application and provide the access token through `headers`. The
+SDK does not open an interactive browser flow.
 
 MCP connections run in the Node SDK process and close with the session. This
 includes MCP used by remote and Cloud sessions: stdio servers see the SDK host

--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ An agent is the persistent entity with memory. A conversation is a thread on tha
 - `resumeSession(conversationId)` resumes a saved conversation.
 - `resumeSession(agentId)` resumes the agent's default conversation.
 
+## Query
+
+`query()` provides the same `query({ prompt, options })` call shape as the
+Claude Agent SDK and streams `SDKMessage` values. Letta additionally accepts an
+optional `agentId`:
+
+```ts
+for await (const message of client.query({
+  prompt: "Review the current changes.",
+  agentId,
+  options: {
+    allowedTools: ["Read", "Glob", "Grep"],
+  },
+})) {
+  if (message.type === "assistant") console.log(message.content);
+  if (message.type === "result") console.log(message.success, message.result);
+}
+```
+
+When `agentId` is supplied, the query creates a new conversation on that
+persistent agent. When it is omitted, the SDK creates a hidden non-MemFS agent
+and forces the conversation into stateless mode. The hidden agent and
+conversation remain server-side resources, but the query does not load or
+change agent memory. A prompt can also be an `AsyncIterable<SendMessage>` for
+multi-turn input on the same conversation.
+
 Pass `stateless: true` when a session should use an existing agent without
 loading or changing its MemFS:
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ for await (const message of client.query({
 ```
 
 When `agentId` is supplied, the query creates a new conversation on that
-persistent agent. When it is omitted, the SDK creates a hidden non-MemFS agent
-and forces the conversation into stateless mode. The hidden agent and
-conversation remain server-side resources, but the query does not load or
-change agent memory. A prompt can also be an `AsyncIterable<SendMessage>` for
-multi-turn input on the same conversation.
+persistent agent. Omit `agentId` and pass `options.model` to create a hidden
+non-MemFS agent with that model and force the conversation into stateless mode.
+The query does not load or change agent memory. Model selection is unavailable
+with `agentId` because session model updates would mutate the persistent agent.
+
+A prompt can also be an `AsyncIterable<SendMessage>`. The SDK consumes that
+iterable concurrently with the output stream, so additional messages can be
+injected or queued while the current turn is running. Long-running queries can
+be controlled directly with `await query.interrupt()` and `query.close()`.
 
 Pass `stateless: true` when a session should use an existing agent without
 loading or changing its MemFS:

--- a/examples/v2-examples.ts
+++ b/examples/v2-examples.ts
@@ -8,7 +8,7 @@
  * Run with: bun examples/v2-examples.ts [example]
  */
 
-import { createAgent, createSession, resumeSession, prompt } from '../src/index.js';
+import { createAgent, createSession, resumeSession, query } from '../src/index.js';
 
 async function main() {
   const example = process.argv[2] || 'basic';
@@ -135,15 +135,17 @@ async function multiTurn() {
 async function oneShot() {
   console.log('=== One-Shot Prompt ===\n');
 
-  // One-shot creates new agent
-  const agentId = await createAgent();
-  const result = await prompt('What is the capital of France? One word.', agentId);
-
-  if (result.success) {
-    console.log(`Answer: ${result.result}`);
-    console.log(`Duration: ${result.durationMs}ms`);
-  } else {
-    console.log(`Error: ${result.error}`);
+  // Omitting agentId creates a hidden stateless agent.
+  for await (const message of query({
+    prompt: 'What is the capital of France? One word.',
+  })) {
+    if (message.type !== 'result') continue;
+    if (message.success) {
+      console.log(`Answer: ${message.result}`);
+      console.log(`Duration: ${message.durationMs}ms`);
+    } else {
+      console.log(`Error: ${message.error}`);
+    }
   }
   console.log();
 }
@@ -209,8 +211,18 @@ async function testOptions() {
   // Test basic session
   console.log('Testing basic session...');
   const agentId = await createAgent();
-  const modelResult = await prompt('Say "model test ok"', agentId);
-  console.log(`  basic: ${modelResult.success ? 'PASS' : 'FAIL'} - ${modelResult.result?.slice(0, 50)}`);
+  let modelResult = '';
+  let modelSucceeded = false;
+  for await (const message of query({
+    prompt: 'Say "model test ok"',
+    agentId,
+  })) {
+    if (message.type === 'result') {
+      modelSucceeded = message.success;
+      modelResult = message.result ?? '';
+    }
+  }
+  console.log(`  basic: ${modelSucceeded ? 'PASS' : 'FAIL'} - ${modelResult.slice(0, 50)}`);
 
   // Test systemPrompt preset via createSession (only presets allowed)
   console.log('Testing systemPrompt preset...');

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -31,9 +31,11 @@ import type {
   ConversationsClient,
   ModelsClient,
 } from "./management-types.js";
+import { createQuery } from "./query.js";
 import type {
   CreateAgentOptions,
   CreateSessionOptions,
+  LettaAgentClientQueryParams,
   LettaCodeBackend,
   LettaCodeClientOptions,
   LettaCodeClientSessionOptions,
@@ -42,8 +44,7 @@ import type {
   LettaCodeLocalClientOptions,
   LettaCodeCloudClientOptions,
   LettaCodeSession,
-  SDKResultMessage,
-  SendMessage,
+  Query,
 } from "./types.js";
 import {
   validateCreateAgentOptions,
@@ -92,10 +93,6 @@ function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
 function looksLikeConversationId(id: string): boolean {
   return id.startsWith("conv-") || id.startsWith("local-conv-");
 }
-
-type OneShotSession = LettaCodeSession & {
-  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
-};
 
 /**
  * Top-level Letta Agent SDK client.
@@ -337,21 +334,13 @@ export class LettaAgentClientBase {
   }
 
   /**
-   * One-shot convenience for scripts, smoke tests, and evals.
-   * Applications should use a session when they need interactive turn state.
+   * Claude Agent SDK-shaped query interface.
+   *
+   * Passing agentId starts a new conversation on that agent. Omitting it
+   * creates a hidden stateless agent for this query.
    */
-  async prompt(
-    message: SendMessage,
-    agentId: string,
-    options: LettaCodeClientSessionOptions = {},
-  ): Promise<SDKResultMessage> {
-    const session = this.createSession(agentId, options);
-
-    try {
-      return await (session as OneShotSession).sendAndWaitForResult(message);
-    } finally {
-      session.close();
-    }
+  query(params: LettaAgentClientQueryParams): Query {
+    return createQuery(this, params);
   }
 
   private assertSessionBackend(

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -334,7 +334,7 @@ export class LettaAgentClientBase {
   }
 
   /**
-   * Claude Agent SDK-shaped query interface.
+   * Stream one or more prompts through a fresh conversation.
    *
    * Passing agentId starts a new conversation on that agent. Omitting it
    * creates a hidden stateless agent for this query.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,9 @@ import type {
   CreateSessionOptions,
   CreateAgentOptions,
   LettaCodeSession,
+  Query,
+  QueryParams,
   SDKInitMessage,
-  SDKResultMessage,
-  SendMessage,
 } from "./types.js";
 import { validateCreateSessionOptions, validateCreateAgentOptions } from "./validation.js";
 
@@ -57,6 +57,10 @@ export type {
   LettaCodeClientOptions,
   LettaCodeClientSessionOptions,
   LettaCodeSession,
+  Query,
+  QueryParams,
+  QueryPrompt,
+  LettaAgentClientQueryParams,
   LettaCodeSocketLike,
   LettaCodeSocketConstructor,
   LettaCodeReactNativeSocketConstructor,
@@ -271,39 +275,29 @@ export function resumeSession(
 }
 
 /**
- * One-shot convenience for scripts, smoke tests, and evals.
+ * Run one or more prompts and stream SDK messages.
  *
- * Creates a short-lived conversation, waits for the final result, and closes
- * the session. Applications that need streaming, approvals, cancellation,
- * queueing, or continued interaction should use createSession() with send()
- * and stream() instead.
+ * The call shape matches Claude Agent SDK's query({ prompt, options }) and
+ * adds an optional agentId. Passing agentId creates a new conversation on that
+ * agent. Omitting it creates a hidden stateless agent under the hood.
  *
  * @example
  * ```typescript
- * const result = await prompt('What is the capital of France?', agentId);  // specific agent
+ * for await (const message of query({
+ *   prompt: 'What is the capital of France?',
+ *   agentId,
+ * })) {
+ *   if (message.type === 'result') console.log(message.result);
+ * }
  * ```
  */
-type OneShotSession = LettaCodeSession & {
-  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
-};
+export function query(params: QueryParams): Query {
+  return new LettaAgentClient().query(params);
+}
 
 type InitializableSession = LettaCodeSession & {
   initialize(): Promise<SDKInitMessage>;
 };
-
-export async function prompt(
-  message: SendMessage,
-  agentId: string,
-  options: CreateSessionOptions = {},
-): Promise<SDKResultMessage> {
-  const session = createSession(agentId, options);
-
-  try {
-    return await (session as OneShotSession).sendAndWaitForResult(message);
-  } finally {
-    session.close();
-  }
-}
 
 // ═══════════════════════════════════════════════════════════════
 // SESSIONLESS APIs

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,9 +277,8 @@ export function resumeSession(
 /**
  * Run one or more prompts and stream SDK messages.
  *
- * The call shape matches Claude Agent SDK's query({ prompt, options }) and
- * adds an optional agentId. Passing agentId creates a new conversation on that
- * agent. Omitting it creates a hidden stateless agent under the hood.
+ * Passing agentId creates a new conversation on that agent. Omitting it
+ * creates a hidden stateless agent under the hood.
  *
  * @example
  * ```typescript

--- a/src/query.ts
+++ b/src/query.ts
@@ -18,6 +18,19 @@ interface QueryClient {
   ): LettaCodeSession;
 }
 
+interface Deferred {
+  promise: Promise<void>;
+  resolve(): void;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 function isPromptStream(prompt: QueryPrompt): prompt is AsyncIterable<SendMessage> {
   return (
     typeof prompt !== "string" &&
@@ -25,14 +38,6 @@ function isPromptStream(prompt: QueryPrompt): prompt is AsyncIterable<SendMessag
     typeof (prompt as AsyncIterable<SendMessage>)[Symbol.asyncIterator] ===
       "function"
   );
-}
-
-async function* prompts(prompt: QueryPrompt): AsyncGenerator<SendMessage> {
-  if (isPromptStream(prompt)) {
-    yield* prompt;
-    return;
-  }
-  yield prompt;
 }
 
 function anonymousQueryOptions(
@@ -64,6 +69,64 @@ function anonymousQueryOptions(
   };
 }
 
+async function* streamPromptInput(
+  session: LettaCodeSession,
+  prompt: AsyncIterable<SendMessage>,
+  isClosed: () => boolean,
+): AsyncGenerator<SDKMessage, void, unknown> {
+  const iterator = prompt[Symbol.asyncIterator]();
+  let inputDone = false;
+  let inputError: unknown;
+  let sentTurns = 0;
+  let completedTurns = 0;
+  let changed = deferred();
+
+  const signalChange = () => {
+    changed.resolve();
+    changed = deferred();
+  };
+
+  const inputPump = (async () => {
+    try {
+      while (!isClosed()) {
+        const next = await iterator.next();
+        if (next.done || isClosed()) break;
+        await session.send(next.value);
+        sentTurns += 1;
+        signalChange();
+      }
+    } catch (error) {
+      inputError = error;
+    } finally {
+      inputDone = true;
+      signalChange();
+    }
+  })();
+
+  try {
+    while (!isClosed()) {
+      if (completedTurns < sentTurns) {
+        for await (const message of session.stream()) {
+          yield message;
+          if (message.type === "result") completedTurns += 1;
+        }
+        continue;
+      }
+      if (inputDone) {
+        if (inputError !== undefined) throw inputError;
+        break;
+      }
+      const nextChange = changed.promise;
+      if (completedTurns >= sentTurns && !inputDone) await nextChange;
+    }
+    if (!isClosed()) await inputPump;
+  } finally {
+    void iterator.return?.().catch(() => {
+      // Closing a query is best-effort cancellation for arbitrary input iterables.
+    });
+  }
+}
+
 /**
  * Run one or more prompts and stream the resulting SDK messages.
  *
@@ -75,9 +138,14 @@ export function createQuery(
   client: QueryClient,
   params: LettaAgentClientQueryParams,
 ): Query {
-  return (async function* runQuery(): AsyncGenerator<SDKMessage, void, unknown> {
-    let session: LettaCodeSession | null = null;
+  let session: LettaCodeSession | null = null;
+  let closed = false;
 
+  const iterator = (async function* runQuery(): AsyncGenerator<
+    SDKMessage,
+    void,
+    unknown
+  > {
     try {
       let agentId = params.agentId;
       let sessionOptions = params.options ?? {};
@@ -86,15 +154,35 @@ export function createQuery(
         const anonymous = anonymousQueryOptions(sessionOptions);
         agentId = await client.createAgent(anonymous.agentOptions);
         sessionOptions = anonymous.sessionOptions;
+      } else if (sessionOptions.model !== undefined) {
+        throw new Error(
+          "query() model selection requires omitting agentId so the SDK can create a stateless agent with that model.",
+        );
       }
 
+      if (closed) return;
       session = client.createSession(agentId, sessionOptions);
-      for await (const prompt of prompts(params.prompt)) {
-        await session.send(prompt);
+      if (isPromptStream(params.prompt)) {
+        yield* streamPromptInput(session, params.prompt, () => closed);
+      } else {
+        await session.send(params.prompt);
         yield* session.stream();
       }
     } finally {
+      closed = true;
       session?.close();
     }
   })();
+
+  return Object.assign(iterator, {
+    async interrupt(): Promise<void> {
+      await session?.abort();
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      session?.close();
+      void iterator.return();
+    },
+  });
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,100 @@
+import type {
+  CreateAgentOptions,
+  LettaAgentClientQueryParams,
+  LettaCodeClientSessionOptions,
+  LettaCodeSession,
+  Query,
+  QueryPrompt,
+  SDKMessage,
+  SendMessage,
+} from "./types.js";
+import { validateCreateSessionOptions } from "./validation.js";
+
+interface QueryClient {
+  createAgent(options?: CreateAgentOptions): Promise<string>;
+  createSession(
+    agentId: string,
+    options?: LettaCodeClientSessionOptions,
+  ): LettaCodeSession;
+}
+
+function isPromptStream(prompt: QueryPrompt): prompt is AsyncIterable<SendMessage> {
+  return (
+    typeof prompt !== "string" &&
+    prompt !== null &&
+    typeof (prompt as AsyncIterable<SendMessage>)[Symbol.asyncIterator] ===
+      "function"
+  );
+}
+
+async function* prompts(prompt: QueryPrompt): AsyncGenerator<SendMessage> {
+  if (isPromptStream(prompt)) {
+    yield* prompt;
+    return;
+  }
+  yield prompt;
+}
+
+function anonymousQueryOptions(
+  options: LettaCodeClientSessionOptions,
+): {
+  agentOptions: CreateAgentOptions;
+  sessionOptions: LettaCodeClientSessionOptions;
+} {
+  if (options.stateless === false) {
+    throw new Error(
+      "query() without agentId always creates a stateless hidden agent; stateless cannot be false.",
+    );
+  }
+
+  const { model, ...rest } = options;
+  const sessionOptions: LettaCodeClientSessionOptions = {
+    ...rest,
+    stateless: true,
+  };
+  validateCreateSessionOptions(sessionOptions);
+
+  return {
+    agentOptions: {
+      ...(model !== undefined ? { model } : {}),
+      hidden: true,
+      memfs: false,
+    },
+    sessionOptions,
+  };
+}
+
+/**
+ * Run one or more prompts and stream the resulting SDK messages.
+ *
+ * An explicit agentId creates a new conversation on that persistent agent.
+ * Without an agentId, query() creates a hidden non-MemFS agent and runs its
+ * conversation in stateless mode.
+ */
+export function createQuery(
+  client: QueryClient,
+  params: LettaAgentClientQueryParams,
+): Query {
+  return (async function* runQuery(): AsyncGenerator<SDKMessage, void, unknown> {
+    let session: LettaCodeSession | null = null;
+
+    try {
+      let agentId = params.agentId;
+      let sessionOptions = params.options ?? {};
+
+      if (agentId === undefined) {
+        const anonymous = anonymousQueryOptions(sessionOptions);
+        agentId = await client.createAgent(anonymous.agentOptions);
+        sessionOptions = anonymous.sessionOptions;
+      }
+
+      session = client.createSession(agentId, sessionOptions);
+      for await (const prompt of prompts(params.prompt)) {
+        await session.send(prompt);
+        yield* session.stream();
+      }
+    } finally {
+      session?.close();
+    }
+  })();
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -154,10 +154,6 @@ export function createQuery(
         const anonymous = anonymousQueryOptions(sessionOptions);
         agentId = await client.createAgent(anonymous.agentOptions);
         sessionOptions = anonymous.sessionOptions;
-      } else if (sessionOptions.model !== undefined) {
-        throw new Error(
-          "query() model selection requires omitting agentId so the SDK can create a stateless agent with that model.",
-        );
       }
 
       if (closed) return;

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1045,34 +1045,93 @@ describe("LettaAgentClient", () => {
     );
   });
 
-  test("query accepts an async prompt stream for multiple turns", async () => {
+  test("query exposes interrupt and close controls", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
     });
+    const runningQuery = client.query({
+      prompt: "hello",
+      agentId: "agent-123",
+    });
+
+    const first = await runningQuery.next();
+    expect(first.value).toMatchObject({ type: "assistant" });
+    await runningQuery.interrupt();
+    expect(fakeControlSocket().sent.at(-1)).toMatchObject({
+      type: "abort_message",
+      runtime: { agent_id: "agent-123", conversation_id: "conv-created" },
+    });
+
+    runningQuery.close();
+    expect(FakeAppServerSocket.instances.every((socket) => socket.readyState === 3)).toBe(
+      true,
+    );
+  });
+
+  test("query rejects model selection on a persistent agent", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const run = async () => {
+      for await (const _message of client.query({
+        prompt: "hello",
+        agentId: "agent-123",
+        options: { model: "anthropic/claude-sonnet-4" },
+      })) {
+        // Query fails before creating a session.
+      }
+    };
+    await expect(run()).rejects.toThrow("model selection requires omitting agentId");
+    expect(FakeAppServerSocket.instances).toHaveLength(0);
+  });
+
+  test("query accepts mid-turn input from an async prompt stream", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+    let injectSecondPrompt!: () => void;
+    const secondPromptReady = new Promise<void>((resolve) => {
+      injectSecondPrompt = resolve;
+    });
     async function* promptStream() {
       yield "first";
+      await secondPromptReady;
       yield "second";
     }
 
     const results = [];
+    let verifiedMidTurnInjection = false;
     for await (const message of client.query({
       prompt: promptStream(),
       agentId: "agent-123",
     })) {
+      if (message.type === "assistant" && !verifiedMidTurnInjection) {
+        injectSecondPrompt();
+        await Bun.sleep(0);
+        const inputs = fakeControlSocket().sent.filter(
+          (command) =>
+            typeof command === "object" &&
+            command !== null &&
+            (command as { type?: string }).type === "input",
+        );
+        expect(inputs).toHaveLength(2);
+        verifiedMidTurnInjection = true;
+      }
       if (message.type === "result") results.push(message);
     }
 
+    expect(verifiedMidTurnInjection).toBe(true);
     expect(results).toHaveLength(2);
-    const inputs = fakeControlSocket().sent.filter(
-      (command) =>
-        typeof command === "object" &&
-        command !== null &&
-        (command as { type?: string }).type === "input",
-    );
-    expect(inputs).toHaveLength(2);
   });
 
   test("query creates a hidden stateless agent when agentId is omitted", async () => {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -675,7 +675,9 @@ describe("LettaAgentClient", () => {
     expect(client.environment).toBeUndefined();
   });
 
-  test("does not export the removed stdio Session implementation", () => {
+  test("exports query instead of the removed prompt API", () => {
+    expect("query" in sdk).toBe(true);
+    expect("prompt" in sdk).toBe(false);
     expect("Session" in sdk).toBe(false);
   });
 
@@ -1006,6 +1008,144 @@ describe("LettaAgentClient", () => {
     } finally {
       session.close();
     }
+  });
+
+  test("query streams a new conversation on an existing agent", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const messages = [];
+    for await (const message of client.query({
+      prompt: "hello",
+      agentId: "agent-123",
+      options: { cwd: "/tmp/project" },
+    })) {
+      messages.push(message);
+    }
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "result",
+        success: true,
+        result: "hello from app-server",
+      }),
+    );
+    expect(fakeControlSocket().sent[0]).toMatchObject({
+      type: "runtime_start",
+      agent_id: "agent-123",
+      create_conversation: { body: {} },
+      cwd: "/tmp/project",
+    });
+    expect(FakeAppServerSocket.instances.every((socket) => socket.readyState === 3)).toBe(
+      true,
+    );
+  });
+
+  test("query accepts an async prompt stream for multiple turns", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+    async function* promptStream() {
+      yield "first";
+      yield "second";
+    }
+
+    const results = [];
+    for await (const message of client.query({
+      prompt: promptStream(),
+      agentId: "agent-123",
+    })) {
+      if (message.type === "result") results.push(message);
+    }
+
+    expect(results).toHaveLength(2);
+    const inputs = fakeControlSocket().sent.filter(
+      (command) =>
+        typeof command === "object" &&
+        command !== null &&
+        (command as { type?: string }).type === "input",
+    );
+    expect(inputs).toHaveLength(2);
+  });
+
+  test("query creates a hidden stateless agent when agentId is omitted", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const messages = [];
+    for await (const message of client.query({
+      prompt: "hello",
+      options: {
+        model: "anthropic/claude-sonnet-4",
+        cwd: "/tmp/project",
+      },
+    })) {
+      messages.push(message);
+    }
+
+    const runtimeStarts = FakeAppServerSocket.instances.flatMap((socket) =>
+      socket.sent.filter(
+        (command): command is Record<string, unknown> =>
+          typeof command === "object" &&
+          command !== null &&
+          (command as { type?: string }).type === "runtime_start",
+      ),
+    );
+    expect(runtimeStarts).toHaveLength(2);
+    expect(runtimeStarts[0]).toMatchObject({
+      create_agent: {
+        memfs: false,
+        pin_global: false,
+        body: {
+          hidden: true,
+          model: "anthropic/claude-sonnet-4",
+        },
+      },
+    });
+    expect(runtimeStarts[1]).toMatchObject({
+      agent_id: "agent-created",
+      create_conversation: { body: {} },
+      cwd: "/tmp/project",
+      stateless: true,
+    });
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "result",
+        success: true,
+        result: "hello from app-server",
+      }),
+    );
+  });
+
+  test("query rejects stateful anonymous sessions before creating an agent", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const run = async () => {
+      for await (const _message of client.query({
+        prompt: "hello",
+        options: { stateless: false },
+      })) {
+        // Query fails before yielding.
+      }
+    };
+    await expect(run()).rejects.toThrow("stateless cannot be false");
+    expect(FakeAppServerSocket.instances).toHaveLength(0);
   });
 
   test("excludes interactive tools by default without pinning an allowlist", async () => {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1071,7 +1071,7 @@ describe("LettaAgentClient", () => {
     );
   });
 
-  test("query rejects model selection on a persistent agent", async () => {
+  test("query applies model selection to the new conversation", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1079,17 +1079,22 @@ describe("LettaAgentClient", () => {
       WebSocket: FakeAppServerSocket,
     });
 
-    const run = async () => {
-      for await (const _message of client.query({
-        prompt: "hello",
-        agentId: "agent-123",
-        options: { model: "anthropic/claude-sonnet-4" },
-      })) {
-        // Query fails before creating a session.
-      }
-    };
-    await expect(run()).rejects.toThrow("model selection requires omitting agentId");
-    expect(FakeAppServerSocket.instances).toHaveLength(0);
+    for await (const _message of client.query({
+      prompt: "hello",
+      agentId: "agent-123",
+      options: { model: "anthropic/claude-sonnet-4" },
+    })) {
+      // Drain the query.
+    }
+
+    expect(fakeControlSocket().sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "update_model",
+          runtime: { agent_id: "agent-123", conversation_id: "conv-created" },
+        }),
+      ]),
+    );
   });
 
   test("query accepts mid-turn input from an async prompt stream", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -736,6 +736,25 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
   filesystemConfinement?: "memory";
 }
 
+/** A single prompt or a stream of prompts for a multi-turn query. */
+export type QueryPrompt = SendMessage | AsyncIterable<SendMessage>;
+
+/** Claude Agent SDK-shaped input for query(). */
+export interface QueryParams<
+  TOptions extends CreateSessionOptions = CreateSessionOptions,
+> {
+  prompt: QueryPrompt;
+  /** Existing Letta agent to use. Omit to create a hidden stateless agent. */
+  agentId?: string;
+  options?: TOptions;
+}
+
+/** Query input accepted by a configured LettaAgentClient. */
+export type LettaAgentClientQueryParams = QueryParams<LettaCodeClientSessionOptions>;
+
+/** Stream returned by query(). */
+export interface Query extends AsyncGenerator<SDKMessage, void, unknown> {}
+
 export interface LettaCodeSession extends AsyncDisposable {
   send(message: SendMessage): Promise<void>;
   stream(): AsyncGenerator<SDKMessage>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -752,8 +752,13 @@ export interface QueryParams<
 /** Query input accepted by a configured LettaAgentClient. */
 export type LettaAgentClientQueryParams = QueryParams<LettaCodeClientSessionOptions>;
 
-/** Stream returned by query(). */
-export interface Query extends AsyncGenerator<SDKMessage, void, unknown> {}
+/** Stream returned by query(), with controls for long-running execution. */
+export interface Query extends AsyncGenerator<SDKMessage, void, unknown> {
+  /** Interrupt the active turn without closing the query session. */
+  interrupt(): Promise<void>;
+  /** Close the query and release its underlying session. */
+  close(): void;
+}
 
 export interface LettaCodeSession extends AsyncDisposable {
   send(message: SendMessage): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -636,7 +636,7 @@ export interface ClientToolsetConfig {
  * For creating new agents with custom memory/persona, use createAgent().
  */
 export interface CreateSessionOptions {
-  /** Model to use (e.g., "claude-sonnet-4-20250514") - updates the agent's LLM config */
+  /** Model override for this conversation (e.g., "openai/gpt-5.6-luna"). */
   model?: string;
 
   /** Reasoning effort tier to use with the selected/current model on websocket protocol sessions. */
@@ -739,7 +739,7 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
 /** A single prompt or a stream of prompts for a multi-turn query. */
 export type QueryPrompt = SendMessage | AsyncIterable<SendMessage>;
 
-/** Claude Agent SDK-shaped input for query(). */
+/** Input accepted by query(). */
 export interface QueryParams<
   TOptions extends CreateSessionOptions = CreateSessionOptions,
 > {


### PR DESCRIPTION
## Summary
- replace `prompt()` with a Claude Agent SDK-shaped `query({ prompt, options })` async message stream
- accept an optional `agentId`; existing agents receive a fresh conversation, while omitted IDs create a hidden non-MemFS agent and force stateless execution
- support `AsyncIterable<SendMessage>` for multi-turn queries and close the underlying session when iteration completes or stops
- stacked on #262, which adds the stateless session transport behavior

## Test plan
- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build`
- [x] live Cloud query without `agentId` returned `QUERY_OK` from a hidden stateless agent

👾 Generated with [Letta Code](https://letta.com)