### PR TITLE
docs: document stream identifier semantics in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,48 @@ the selected transport adapter.
 Those methods operate at different layers and should not be combined merely
 because they share a name.
 
+## Stream identifiers
+
+Streamed `SDKMessage` values carry several identifiers, and each one answers a
+different question. Most duplicate or missing message bugs in consumers come
+from using one to answer another's question.
+
+- `seqId` answers "have I already processed this stream position?" It is a
+  per-run replay cursor: use it to suppress replayed events after a resume or
+  reconnect, compare it only within the same `runId`, and reset the threshold
+  when a new run starts. It is not row identity.
+- `otid` answers "which typed message slice is this?" Use it to reassemble the
+  fragments of one slice. It is not a universal key across message types.
+- `uuid` answers "which message object is this?" Use it for message identity
+  and for history cursoring and backfill. It is the top-level message ID when
+  the stream provides one and an SDK-generated identifier otherwise, so it is
+  neither a guaranteed server ID nor a replay cursor.
+- `toolCallId` answers "which tool call is this about?" Use it to join a
+  `tool_call` with its `tool_result`. It is not identity for assistant or
+  reasoning messages.
+
+Only `assistant` and `reasoning` carry `otid` and `seqId`; `tool_call` and
+`tool_result` carry `toolCallId` and `uuid`. Identity therefore has to be
+decided per message family. A single generic `seqId → otid → uuid` fallback
+chain applied to every message will merge unrelated rows.
+
+- Key `assistant` and `reasoning` accumulators on the message type together
+  with `otid`, not on `otid` alone. A provider can reuse an `otid` across
+  kinds, which collapses assistant text into reasoning. Fall back to `uuid`
+  only within the same family — `src/tests/stream-message-identity.test.ts`
+  pins the case where two slices share a `uuid` and differ only by type and
+  `otid`.
+- Merge tool arguments and results by `toolCallId`, but do not flatten every
+  tool-family message onto it. Envelope identity and tool-payload identity are
+  distinct.
+- Do not merge persisted history into a transcript while a turn is streaming.
+  When backfill after a reconnect is unavoidable, rebase the in-progress
+  accumulators onto the fetched rows; otherwise later fragments append to a
+  stale baseline and the row renders twice.
+- Mid-stream, `tool_call.toolInput` is `{ raw: "<chunk>" }` until the argument
+  fragments parse as JSON. Accumulate `rawArguments` and parse once at the end
+  rather than overwriting parsed arguments with a partial wrapper.
+
 ## Cloud API ownership
 
 - `@letta-ai/letta-code` owns the agent harness, app-server protocol, runtime


### PR DESCRIPTION
Closes #268.

## Why

`AGENTS.md` is the contributor map for this repo and it is shipped in the published package (`files` includes it), but it said nothing about identifier semantics. Every streamed `SDKMessage` carries `seqId`, `otid`, `uuid`, and/or `toolCallId`, and each answers a different question — the type comments say so per field, but nothing in the repo explains how they compose into a merge strategy.

The evidence that this contract is undiscoverable today is our own React chat demo: it merges streamed fragments by array position rather than by any identifier. That is what a consumer does when the repo gives them nothing to key on, and it is exactly the shape of bug (duplicate rows, assistant text collapsing into reasoning) that the rules below prevent.

## What

One new `## Stream identifiers` section, placed after "Session architecture" (where the `SDKMessage` stream queue is introduced) and before "Cloud API ownership":

- what question each of `seqId` / `otid` / `uuid` / `toolCallId` answers, and what it must not be used for;
- which fields exist on which message families — only `assistant` and `reasoning` carry `otid`/`seqId`, `tool_call`/`tool_result` carry `toolCallId` and `uuid` — so identity has to be typed rather than resolved through one generic `seqId → otid → uuid` chain;
- key `assistant`/`reasoning` accumulators on message type *plus* `otid`, since a provider can reuse an `otid` across kinds (`src/tests/stream-message-identity.test.ts` already pins the case where two slices share a `uuid` and differ only by type and `otid`);
- merge tool arguments and results by `toolCallId` without flattening the whole tool family onto it;
- do not merge persisted history while a turn is streaming; rebase in-progress accumulators if backfill after reconnect is unavoidable;
- mid-stream `tool_call.toolInput` is `{ raw: "<chunk>" }` until the arguments parse as JSON, so accumulate `rawArguments` and parse once at the end.

Wording was checked against `src/types.ts` and `src/remote-session-protocol.ts` (`toolInputFromArguments`) so the section agrees with the code rather than restating it loosely.

## Testing

Docs-only change; the repo has no markdown linter or pre-commit hook. Ran the standard gates anyway:

- `bun run check` — pass (tsc clean, source-size budgets pass)
- `bun test` — 216 pass, 11 skip, 0 fail
- `bun run build` not run: no source files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
