### PR TITLE
feat(send): accept a caller-supplied otid on send()

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ An agent is the persistent entity with memory. A conversation is a thread on tha
 - `resumeSession(conversationId)` resumes a saved conversation.
 - `resumeSession(agentId)` resumes the agent's default conversation.
 
+Pass your own OTID when you render the user message optimistically, so you can
+match the row you drew with the persisted one:
+
+```ts
+const otid = crypto.randomUUID();
+await session.send("Summarize today's changes.", { otid });
+```
+
+The OTID is stored on the persisted user message (visible via `listMessages()`)
+and doubles as the turn's `clientMessageId`, so it also identifies the message
+in `queue_update` events while it is queued. The SDK generates one when the
+option is omitted.
+
 Pass `stateless: true` when a session should use an existing agent without
 loading or changing its MemFS:
 

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -407,6 +407,9 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
           role: "user",
           content: normalizeSendMessage(message),
           client_message_id: options.clientMessageId,
+          // The runtime stamps an OTID from client_message_id when the caller
+          // omits one; sending it explicitly keeps the caller's value canonical.
+          ...(options.otid !== undefined ? { otid: options.otid } : {}),
         },
       ],
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export type {
   ImageContent,
   MessageContentItem,
   SendMessage,
+  SendOptions,
   // List messages API
   ListMessagesOptions,
   ListMessagesResult,

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -20,6 +20,7 @@ import type {
   SDKResultMessage,
   SendCommandOptions,
   SendMessage,
+  SendOptions,
   SessionDeviceStatus,
   UpdateModelOptions,
   UpdateModelResult,
@@ -43,6 +44,7 @@ import {
   resolveDreamingSettings,
   sameContextCandidates,
   toBaseModelHandle,
+  turnSendOptions,
   type NormalizedUpdateModelInput,
   type RemoteClientSessionCoreConfig,
   type RemoteClientRuntimeController,
@@ -207,7 +209,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     this.initialized = false;
   }
 
-  async send(message: SendMessage): Promise<void> {
+  async send(message: SendMessage, options?: SendOptions): Promise<void> {
     if (this.closed) throw new Error("Session is closed");
     if (!this.initialized) {
       await this.initialize();
@@ -224,11 +226,9 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     if (!controller || !runtime) {
       throw new Error("Session transport disconnected before the turn was sent");
     }
-    const turn = this.turns.trackSentTurn(runtime);
+    const turn = this.turns.trackSentTurn(runtime, options?.otid);
     try {
-      controller.sendTurnMessage(runtime, message, {
-        clientMessageId: turn.clientMessageId,
-      });
+      controller.sendTurnMessage(runtime, message, turnSendOptions(turn));
     } catch (error) {
       this.turns.removeTrackedTurn(turn);
       throw error;

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -55,6 +55,8 @@ export type RuntimeTurnResult = {
 
 export type RuntimeSendTurnOptions = {
   clientMessageId: string;
+  /** Caller-supplied OTID for the user message, when one was provided. */
+  otid?: string;
 };
 
 export type RuntimeRequestOptions = {
@@ -128,6 +130,8 @@ export type TurnTracker = {
   id: number;
   runtime: RuntimeScope;
   clientMessageId: string;
+  /** Caller-supplied OTID for this turn's user message, when one was provided. */
+  otid?: string;
   queuedAt: number;
   startedAt: number;
   assistantText: string;
@@ -676,4 +680,24 @@ export function toSessionDeviceStatus(
 
 export function normalizeSendMessage(message: SendMessage): string | MessageContentItem[] {
   return message;
+}
+
+/**
+ * Validate a caller-supplied OTID. Empty/whitespace-only values would silently
+ * defeat correlation, so they are rejected instead of being dropped.
+ */
+export function normalizeCallerOtid(otid: string | undefined): string | undefined {
+  if (otid === undefined) return undefined;
+  if (typeof otid !== "string" || otid.trim() === "") {
+    throw new Error("send() otid must be a non-empty string");
+  }
+  return otid;
+}
+
+/** Wire correlation options for a tracked turn. */
+export function turnSendOptions(turn: TurnTracker): RuntimeSendTurnOptions {
+  return {
+    clientMessageId: turn.clientMessageId,
+    ...(turn.otid !== undefined ? { otid: turn.otid } : {}),
+  };
 }

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -15,6 +15,7 @@ import {
   isApprovalConflictSignal,
   loopStatusRunIds,
   loopStatusValue,
+  normalizeCallerOtid,
   queueItems,
   sameRuntime,
   streamDeltaMessageType,
@@ -76,11 +77,19 @@ export class RemoteTurnCoordinator {
     return this.activeTurn !== null || this.pendingTurns.length > 0;
   }
 
-  trackSentTurn(runtime: RuntimeScope): TurnTracker {
+  /**
+   * Start tracking a turn. A caller-supplied OTID doubles as the turn's
+   * `clientMessageId` so queue updates carry the same correlation id the
+   * persisted message will; otherwise the SDK mints one.
+   */
+  trackSentTurn(runtime: RuntimeScope, callerOtid?: string): TurnTracker {
+    const otid = normalizeCallerOtid(callerOtid);
     const turn: TurnTracker = {
       id: ++this.nextTurnId,
       runtime,
-      clientMessageId: `sdk-message-${Date.now()}-${++this.clientMessageCounter}`,
+      ...(otid !== undefined ? { otid } : {}),
+      clientMessageId:
+        otid ?? `sdk-message-${Date.now()}-${++this.clientMessageCounter}`,
       queuedAt: Date.now(),
       startedAt: 0,
       assistantText: "",

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1424,6 +1424,113 @@ describe("LettaAgentClient", () => {
     }
   });
 
+  test("send() forwards a caller-supplied otid as the wire otid and client_message_id", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "normal";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      await asAdvanced(session).initialize();
+      await session.send("hello", { otid: "otid-from-caller" });
+
+      const inputCommand = fakeControlSocket().sent.find(
+        (sent) => (sent as { type?: string }).type === "input",
+      ) as { payload: { messages: Array<Record<string, unknown>> } } | undefined;
+      expect(inputCommand?.payload.messages[0]).toMatchObject({
+        role: "user",
+        content: "hello",
+        otid: "otid-from-caller",
+        client_message_id: "otid-from-caller",
+      });
+    } finally {
+      session.close();
+    }
+  });
+
+  test("send() generates a client message id and omits otid when the caller supplies none", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "normal";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      await asAdvanced(session).initialize();
+      await session.send("hello");
+
+      const inputCommand = fakeControlSocket().sent.find(
+        (sent) => (sent as { type?: string }).type === "input",
+      ) as { payload: { messages: Array<Record<string, unknown>> } } | undefined;
+      const message = inputCommand?.payload.messages[0];
+      expect(typeof message?.client_message_id).toBe("string");
+      expect(message?.client_message_id as string).toMatch(/^sdk-message-/);
+      expect(message).not.toHaveProperty("otid");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("send() rejects an empty caller-supplied otid", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "normal";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      await asAdvanced(session).initialize();
+      await expect(session.send("hello", { otid: "   " })).rejects.toThrow(
+        "send() otid must be a non-empty string",
+      );
+      expect(
+        fakeControlSocket().sent.some((sent) => (sent as { type?: string }).type === "input"),
+      ).toBe(false);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a caller-supplied otid is the correlation id on queued message updates", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "queuedSecond";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      await asAdvanced(session).initialize();
+      await session.send("first message");
+      await session.send("second message", { otid: "otid-queued" });
+
+      const iterator = session.stream();
+      expect((await iterator.next()).value).toMatchObject({
+        type: "assistant",
+        content: "first response",
+      });
+      expect((await iterator.next()).value).toMatchObject({
+        type: "queue_update",
+        queue: [expect.objectContaining({ clientMessageId: "otid-queued" })],
+      });
+    } finally {
+      FakeAppServerSocket.inputScenario = "normal";
+      session.close();
+    }
+  });
+
   test("creates remote app-server agents through runtime_start", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,25 @@ export type MessageContentItem = TextContent | ImageContent;
  */
 export type SendMessage = string | MessageContentItem[];
 
+/**
+ * Per-turn options accepted by `send()`.
+ */
+export interface SendOptions {
+  /**
+   * Caller-supplied offline threading id (OTID) for this user message.
+   *
+   * The OTID is the canonical optimistic-input-matching key: stamp the row you
+   * render optimistically with the same value and you can correlate it with the
+   * persisted user message that comes back from the stream or from
+   * `listMessages()`. It is also used as the turn's `clientMessageId`, so it
+   * shows up on `SDKQueueItem.clientMessageId` while the message is queued.
+   *
+   * When omitted the SDK generates one. Must be a non-empty string; reuse the
+   * same value when retrying a send so the runtime can deduplicate it.
+   */
+  otid?: string;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // SKILLS / REMINDER / DREAMING TYPES
 // ═══════════════════════════════════════════════════════════════
@@ -737,7 +756,11 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
 }
 
 export interface LettaCodeSession extends AsyncDisposable {
-  send(message: SendMessage): Promise<void>;
+  /**
+   * Send a user message. Pass `{ otid }` to supply your own correlation id for
+   * optimistic reconciliation; the SDK generates one when omitted.
+   */
+  send(message: SendMessage, options?: SendOptions): Promise<void>;
   stream(): AsyncGenerator<SDKMessage>;
   abort(): Promise<void>;
   sendCommand(command: SDKProtocolCommand): Promise<void>;


### PR DESCRIPTION
Closes #270.

## What

`send()` takes an optional second argument so a caller can supply the correlation id for the user message it is about to render optimistically:

```ts
const otid = crypto.randomUUID();
await session.send("Summarize today's changes.", { otid });
```

```ts
export interface SendOptions {
  /** Caller-supplied OTID for this user message. Generated when omitted. */
  otid?: string;
}

send(message: SendMessage, options?: SendOptions): Promise<void>;
```

Semantics:

- The caller value is sent as the wire `otid` on the `create_message` payload, so it lands on the persisted user message (visible as `otid` on the raw rows from `listMessages()` / `bootstrapState()`).
- It also becomes the turn's `client_message_id`, so the same id shows up on `SDKQueueItem.clientMessageId` in `queue_update` events while the message is queued. One id correlates the optimistic row, the queue entry, and the persisted row.
- Omitting it preserves today's behavior exactly: the SDK mints `sdk-message-<ts>-<n>` as the `client_message_id` and sends no `otid`.
- An empty/whitespace-only `otid` throws (`send() otid must be a non-empty string`) instead of silently defeating correlation. It throws before anything reaches the wire.
- Reusing the same `otid` on a retry is the documented idempotency path — the runtime deduplicates on it.

`SendOptions` is exported from the package root and, via `export type *`, from the portable `/client` entry, which shares `LettaCodeSession` with the root. Both entries pick the change up from the single `types.ts` declaration.

## Full otid support was possible — no protocol limitation

I checked the wire before assuming, since the issue left it open:

- `InputCreateMessagePayload.messages` is `Array<MessageCreate & { client_message_id?: string }>` (`@letta-ai/letta-code` `types/protocol_v2.d.ts`), and `MessageCreate` already carries `otid?: string | null` — the offline threading id used for dedupe/idempotency.
- The listener only *defaults* the otid when the caller omits it: `stampInboundUserMessageOtids()` and `ensureTurnInputMessageOtids()` both return the payload untouched when `payload.otid` is set, and otherwise fall back to `client_message_id` (then `crypto.randomUUID()`).
- Local transcript writes read `message.otid ?? message.client_message_id`.

So a caller-supplied otid is honored end to end; nothing had to be invented. Sending it explicitly (rather than relying on the `client_message_id` fallback) keeps the caller's value canonical on transports that do not apply that fallback.

## Scope

Deliberately limited to the `send()` / `SendMessage` path: `types.ts` (the `SendOptions` type and the `LettaCodeSession.send` signature), the turn coordinator's id minting, the `RuntimeSendTurnOptions` plumbing, and the `create_message` payload. `sendAndWaitForResult()` and `prompt()` are untouched — they are one-shot helpers with no optimistic row to reconcile; say the word and I will thread the option through them too.

`remote-client-session-core.ts` sits exactly at its 900-line source-size ceiling, so the send-site change is net-zero on line count: the inline wire-options literal moved into a `turnSendOptions(turn)` helper next to `TurnTracker` in `remote-session-protocol.ts`.

## Tests

Four tests added to `src/tests/client.test.ts`, using the existing `FakeAppServerSocket` harness:

- a caller-supplied otid is forwarded as both `otid` and `client_message_id` on the wire;
- omitting it still generates an `sdk-message-*` `client_message_id` and sends no `otid`;
- a caller-supplied otid is the `clientMessageId` on the resulting `queue_update` item;
- an empty otid rejects and sends no input command.

## Checks

- `bun run check` (tsc + source-size budget): pass
- `bun test`: 220 pass, 11 skip, 0 fail (231 across 22 files)
- `bun run build`: pass

The repo has no separate lint script; `check` is tsc plus the source-size budget. Note: the source-size budget passes on this branch and on unmodified `main` — `remote-client-session-core.ts` is at 900/900, i.e. one line from failing, which is why the send-site edit was kept net-zero rather than growing the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)