### PR TITLE
feat: export a transcript accumulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,41 @@ cached before the app was backgrounded. Pending approval request IDs are for
 correlation; decisions continue through `recoverPendingApprovals()` and the
 session's `canUseTool` callback.
 
+## Rendering a transcript
+
+`session.stream()` emits message slices, not rows. Reconciling them into a
+conversation view means merging text fragments by message family and `otid`,
+dropping replayed `seqId` positions per run, and merging tool arguments and
+results by `toolCallId`. `createTranscriptAccumulator()` does that for you and
+is available from the package root and `/client`:
+
+```ts
+import { createTranscriptAccumulator } from "@letta-ai/letta-agent-sdk";
+
+const transcript = createTranscriptAccumulator();
+
+await session.send("Summarize the repo");
+for await (const message of session.stream()) {
+  const rows = transcript.apply(message);
+  render(rows); // TranscriptRow[]: user | assistant | reasoning | tool_call
+}
+
+// Safe mid-run: merge older history without duplicating in-flight rows.
+transcript.rebase(await session.listMessages({ limit: 50 }));
+```
+
+Each row carries a stable `key` for list rendering, plus the identifiers it was
+reconciled from (`uuid`, `otid`, `runId`, `seqId`). Tool rows expose the payload
+identity (`toolCallId`) separately from the envelopes that produced them, along
+with `argumentsComplete` and a `status` of `streaming`, `ready`, or `complete`,
+so a partially streamed argument object is never rendered as final input.
+
+`apply()` returns the same array reference when a message changed nothing (a
+replayed position, or a turn-level message such as `result`), so memoized
+renderers can skip the update. Turn-level messages (`init`, `result`, `error`,
+`retry`, `queue_update`, `loop_status`) are not transcript rows; handle them
+directly.
+
 ## Deployment options
 
 | Backend | Agent state | Tool execution |

--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -36,5 +36,19 @@ export type {
 } from "./computers.js";
 export type * from "./management-types.js";
 export { extractStreamTextDelta } from "./stream-events.js";
+export { createTranscriptAccumulator } from "./transcript-accumulator.js";
+export type {
+  TranscriptAccumulator,
+  TranscriptHistoryPage,
+  TranscriptRebaseOptions,
+  TranscriptRow,
+  TranscriptRowIdentity,
+  TranscriptRowKind,
+  TranscriptTextKind,
+  TranscriptTextRow,
+  TranscriptToolCallRow,
+  TranscriptToolCallStatus,
+  TranscriptToolResult,
+} from "./transcript-accumulator.js";
 export { createReactNativeWebSocketConstructor } from "./websocket.js";
 export type * from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,20 @@ export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 export { createReactNativeWebSocketConstructor } from "./websocket.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";
+export { createTranscriptAccumulator } from "./transcript-accumulator.js";
+export type {
+  TranscriptAccumulator,
+  TranscriptHistoryPage,
+  TranscriptRebaseOptions,
+  TranscriptRow,
+  TranscriptRowIdentity,
+  TranscriptRowKind,
+  TranscriptTextKind,
+  TranscriptTextRow,
+  TranscriptToolCallRow,
+  TranscriptToolCallStatus,
+  TranscriptToolResult,
+} from "./transcript-accumulator.js";
 
 // Tool helpers
 export {

--- a/src/tests/portable-client.test.ts
+++ b/src/tests/portable-client.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 import {
   LettaAgentClient,
   createReactNativeWebSocketConstructor,
+  createTranscriptAccumulator,
+  extractStreamTextDelta,
   type LettaCodeReactNativeSocketConstructor,
   type LettaCodeSocketOptions,
+  type TranscriptRow,
 } from "../client-entry.js";
 
 describe("portable client entry", () => {
@@ -82,5 +85,22 @@ describe("portable client entry", () => {
       protocols: undefined,
       options: { headers: { Authorization: "Bearer token" } },
     });
+  });
+
+  test("exports the streaming helpers browser consumers need", () => {
+    expect(typeof extractStreamTextDelta).toBe("function");
+
+    const accumulator = createTranscriptAccumulator();
+    const rows: readonly TranscriptRow[] = accumulator.apply({
+      type: "assistant",
+      content: "hello",
+      uuid: "m1",
+      otid: "o1",
+      seqId: 1,
+      runId: "r1",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "assistant", text: "hello" });
   });
 });

--- a/src/tests/transcript-accumulator.test.ts
+++ b/src/tests/transcript-accumulator.test.ts
@@ -1,0 +1,689 @@
+/**
+ * Unit tests for the transcript accumulator.
+ *
+ * These cover the reconciliation rules a consumer would otherwise hand-roll:
+ * typed-by-family otid merging, per-run seqId replay suppression, toolCallId
+ * payload merging, the transitional `{ raw }` argument wrapper, and mid-run
+ * history backfill.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { createTranscriptAccumulator } from "../transcript-accumulator.js";
+import type {
+  TranscriptRow,
+  TranscriptTextRow,
+  TranscriptToolCallRow,
+} from "../transcript-accumulator.js";
+import type { SDKMessage } from "../types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function assistant(
+  content: string,
+  identity: { uuid: string; otid?: string; seqId?: number; runId?: string },
+): SDKMessage {
+  return { type: "assistant", content, ...identity };
+}
+
+function reasoning(
+  content: string,
+  identity: { uuid: string; otid?: string; seqId?: number; runId?: string },
+): SDKMessage {
+  return { type: "reasoning", content, ...identity };
+}
+
+function toolCallFragment(
+  toolCallId: string,
+  rawArguments: string,
+  extra: { uuid: string; toolName?: string; runId?: string },
+): SDKMessage {
+  return {
+    type: "tool_call",
+    toolCallId,
+    toolName: extra.toolName ?? "Bash",
+    // Mirrors `toolInputFromArguments()`: an unparseable fragment arrives
+    // wrapped as `{ raw }`.
+    toolInput: parsedOrWrapper(rawArguments),
+    rawArguments,
+    uuid: extra.uuid,
+    ...(extra.runId ? { runId: extra.runId } : {}),
+  };
+}
+
+function parsedOrWrapper(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through
+  }
+  return { raw };
+}
+
+function historyMessage(record: Record<string, unknown>): Message {
+  return record as unknown as Message;
+}
+
+function textRows(rows: readonly TranscriptRow[]): TranscriptTextRow[] {
+  return rows.filter((row): row is TranscriptTextRow => row.kind !== "tool_call");
+}
+
+function toolRows(rows: readonly TranscriptRow[]): TranscriptToolCallRow[] {
+  return rows.filter((row): row is TranscriptToolCallRow => row.kind === "tool_call");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typed-by-family accumulation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("typed-by-family accumulation", () => {
+  test("merges assistant fragments sharing an otid into one row", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("Hel", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    const rows = acc.apply(
+      assistant("lo", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "assistant",
+      text: "Hello",
+      uuid: "m1",
+      otid: "o1",
+      runId: "r1",
+      seqId: 2,
+    });
+  });
+
+  test("keeps assistant and reasoning apart when a provider reuses one otid", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("answer", { uuid: "m1", otid: "shared", seqId: 1, runId: "r1" }));
+    const rows = acc.apply(
+      reasoning("thought", { uuid: "m2", otid: "shared", seqId: 2, runId: "r1" }),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["assistant", "answer"],
+      ["reasoning", "thought"],
+    ]);
+    expect(new Set(rows.map((row) => row.key)).size).toBe(2);
+  });
+
+  test("falls back to uuid only within a family", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("answer", { uuid: "shared", seqId: 1, runId: "r1" }));
+    acc.apply(assistant(" more", { uuid: "shared", seqId: 2, runId: "r1" }));
+    const rows = acc.apply(
+      reasoning("thought", { uuid: "shared", seqId: 3, runId: "r1" }),
+    );
+
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["assistant", "answer more"],
+      ["reasoning", "thought"],
+    ]);
+  });
+
+  test("keeps one row when a stream transitions from id-only to id+otid", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("Hel", { uuid: "m1", seqId: 1, runId: "r1" }));
+    const rows = acc.apply(
+      assistant("lo", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ text: "Hello", otid: "o1" });
+  });
+
+  test("opens a new row when a second otid reuses a committed message id", () => {
+    const acc = createTranscriptAccumulator();
+    // Anthropic-style [text, thinking, text] under one message id.
+    acc.apply(assistant("first", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    acc.apply(reasoning("thinking", { uuid: "m1", otid: "o2", seqId: 2, runId: "r1" }));
+    const rows = acc.apply(
+      assistant("second", { uuid: "m1", otid: "o3", seqId: 3, runId: "r1" }),
+    );
+
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["assistant", "first"],
+      ["reasoning", "thinking"],
+      ["assistant", "second"],
+    ]);
+  });
+
+  test("continues the newest slice for later id-only fragments", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("first", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    acc.apply(assistant("second", { uuid: "m1", otid: "o2", seqId: 2, runId: "r1" }));
+    const rows = acc.apply(assistant("-tail", { uuid: "m1", seqId: 3, runId: "r1" }));
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["first", "second-tail"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Replay suppression
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("per-run seqId replay suppression", () => {
+  test("drops replayed positions after a resume", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("a", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    acc.apply(assistant("b", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }));
+
+    // Reconnect replays the whole run from the start.
+    acc.apply(assistant("a", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    acc.apply(assistant("b", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }));
+    const rows = acc.apply(
+      assistant("c", { uuid: "m1", otid: "o1", seqId: 3, runId: "r1" }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as TranscriptTextRow).text).toBe("abc");
+  });
+
+  test("returns a referentially stable snapshot for suppressed replays", () => {
+    const acc = createTranscriptAccumulator();
+    const first = acc.apply(
+      assistant("a", { uuid: "m1", otid: "o1", seqId: 7, runId: "r1" }),
+    );
+    const replayed = acc.apply(
+      assistant("a", { uuid: "m1", otid: "o1", seqId: 7, runId: "r1" }),
+    );
+
+    expect(replayed).toBe(first);
+  });
+
+  test("resets the threshold for a new run", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("old", { uuid: "m1", otid: "o1", seqId: 42, runId: "r1" }));
+    const rows = acc.apply(
+      assistant("new", { uuid: "m2", otid: "o2", seqId: 1, runId: "r2" }),
+    );
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["old", "new"]);
+  });
+
+  test("keeps suppressing an older run after a newer run starts", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("old", { uuid: "m1", otid: "o1", seqId: 42, runId: "r1" }));
+    acc.apply(assistant("new", { uuid: "m2", otid: "o2", seqId: 1, runId: "r2" }));
+    const rows = acc.apply(
+      assistant("old", { uuid: "m1", otid: "o1", seqId: 42, runId: "r1" }),
+    );
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["old", "new"]);
+  });
+
+  test("does not suppress across runs that reuse the same positions", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("one", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    acc.apply(assistant("two", { uuid: "m2", otid: "o2", seqId: 1, runId: "r2" }));
+    const rows = acc.apply(
+      assistant("three", { uuid: "m3", otid: "o3", seqId: 1, runId: "r3" }),
+    );
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["one", "two", "three"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool merging
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolCallId-keyed merging", () => {
+  test("merges argument fragments and the tool result into one row", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(toolCallFragment("call-1", '{"command"', { uuid: "env-1" }));
+    let rows = acc.apply(toolCallFragment("call-1", ':"echo hi"', { uuid: "env-2" }));
+
+    expect(toolRows(rows)[0]).toMatchObject({
+      toolCallId: "call-1",
+      argumentsComplete: false,
+      status: "streaming",
+      toolInput: {},
+    });
+
+    rows = acc.apply(toolCallFragment("call-1", "}", { uuid: "env-3" }));
+    expect(toolRows(rows)[0]).toMatchObject({
+      argumentsComplete: true,
+      status: "ready",
+      toolInput: { command: "echo hi" },
+      rawArguments: '{"command":"echo hi"}',
+    });
+
+    rows = acc.apply({
+      type: "tool_result",
+      toolCallId: "call-1",
+      content: "hi",
+      isError: false,
+      uuid: "env-result",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(toolRows(rows)[0]).toMatchObject({
+      status: "complete",
+      toolInput: { command: "echo hi" },
+      result: { content: "hi", isError: false, uuid: "env-result" },
+    });
+  });
+
+  test("keeps envelope identity distinct from payload identity", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(toolCallFragment("call-1", '{"command":"ls"}', { uuid: "env-call" }));
+    const rows = acc.apply({
+      type: "tool_result",
+      toolCallId: "call-1",
+      content: "a\nb",
+      isError: false,
+      uuid: "env-result",
+    });
+
+    const row = toolRows(rows)[0]!;
+    // The row is keyed on the payload id, while both envelopes stay readable.
+    expect(row.key).toContain("call-1");
+    expect(row.toolCallId).toBe("call-1");
+    expect(row.uuid).toBe("env-call");
+    expect(row.result?.uuid).toBe("env-result");
+  });
+
+  test("never lets the transitional { raw } wrapper overwrite parsed args", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(toolCallFragment("call-1", '{"command":"echo hi"}', { uuid: "env-1" }));
+    // A replayed partial fragment arrives after the arguments already parsed.
+    const rows = acc.apply(toolCallFragment("call-1", '{"comm', { uuid: "env-2" }));
+
+    const row = toolRows(rows)[0]!;
+    expect(row.toolInput).toEqual({ command: "echo hi" });
+    expect(row.argumentsComplete).toBe(true);
+    expect(row.toolInput.raw).toBeUndefined();
+  });
+
+  test("does not report unparsed fragments as complete arguments", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.apply(toolCallFragment("call-1", '{"command":"ec', { uuid: "e1" }));
+
+    const row = toolRows(rows)[0]!;
+    expect(row.argumentsComplete).toBe(false);
+    expect(row.toolInput).toEqual({});
+    expect(row.rawArguments).toBe('{"command":"ec');
+  });
+
+  test("treats an argument-free call as complete", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.apply({
+      type: "tool_call",
+      toolCallId: "call-1",
+      toolName: "ListTools",
+      toolInput: {},
+      uuid: "env-1",
+    });
+
+    expect(toolRows(rows)[0]).toMatchObject({
+      argumentsComplete: true,
+      status: "ready",
+    });
+  });
+
+  test("creates a row for a tool result that arrives without its call", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.apply({
+      type: "tool_result",
+      toolCallId: "call-orphan",
+      content: "boom",
+      isError: true,
+      uuid: "env-result",
+    });
+
+    expect(toolRows(rows)[0]).toMatchObject({
+      toolCallId: "call-orphan",
+      toolName: "?",
+      status: "complete",
+      result: { content: "boom", isError: true },
+    });
+  });
+
+  test("keeps a known tool name when a later fragment omits it", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(toolCallFragment("call-1", '{"command"', { uuid: "e1", toolName: "Bash" }));
+    const rows = acc.apply(
+      toolCallFragment("call-1", ':"ls"}', { uuid: "e2", toolName: "?" }),
+    );
+
+    expect(toolRows(rows)[0]?.toolName).toBe("Bash");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stream_event composition
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("stream_event composition", () => {
+  test("folds identified stream events into the same rows as cooked messages", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply({
+      type: "stream_event",
+      uuid: "generated-1",
+      event: {
+        message_type: "assistant_message",
+        id: "m1",
+        otid: "o1",
+        seq_id: 1,
+        run_id: "r1",
+        content: "Hel",
+      },
+    });
+    const rows = acc.apply(
+      assistant("lo", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as TranscriptTextRow).text).toBe("Hello");
+  });
+
+  test("folds anonymous content_block deltas into one live row per family", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply({
+      type: "stream_event",
+      uuid: "generated-1",
+      event: { type: "content_block_delta", delta: { text: "Hel" } },
+    });
+    acc.apply({
+      type: "stream_event",
+      uuid: "generated-2",
+      event: { type: "content_block_delta", delta: { text: "lo" } },
+    });
+    const rows = acc.apply({
+      type: "stream_event",
+      uuid: "generated-3",
+      event: { type: "content_block_delta", delta: { reasoning: "hmm" } },
+    });
+
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["assistant", "Hello"],
+      ["reasoning", "hmm"],
+    ]);
+  });
+
+  test("ignores turn-level messages", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.apply({
+      type: "result",
+      success: true,
+      durationMs: 12,
+      conversationId: "conv-1",
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rebase()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rebase()", () => {
+  test("merges a newest-first history page into ascending rows", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.rebase({
+      messages: [
+        historyMessage({
+          id: "m2",
+          message_type: "assistant_message",
+          content: "hi there",
+          otid: "o2",
+          seq_id: 2,
+          run_id: "r1",
+          date: "2026-07-28T00:00:02Z",
+        }),
+        historyMessage({
+          id: "m1",
+          message_type: "user_message",
+          content: "hello",
+          otid: "o1",
+          seq_id: 1,
+          run_id: "r1",
+          date: "2026-07-28T00:00:01Z",
+        }),
+      ],
+    });
+
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["user", "hello"],
+      ["assistant", "hi there"],
+    ]);
+  });
+
+  test("honors an explicit order override", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.rebase(
+      [
+        historyMessage({ id: "m1", message_type: "user_message", content: "one" }),
+        historyMessage({ id: "m2", message_type: "user_message", content: "two" }),
+      ],
+      { order: "asc" },
+    );
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["one", "two"]);
+  });
+
+  test("does not duplicate rows already built from the live stream", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("Hel", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }));
+    const rows = acc.rebase([
+      historyMessage({
+        id: "m1",
+        message_type: "assistant_message",
+        content: "Hello",
+        otid: "o1",
+        seq_id: 1,
+        run_id: "r1",
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as TranscriptTextRow).text).toBe("Hello");
+  });
+
+  test("backfills mid-stream and keeps accumulating the continued fragments", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("Hel", { uuid: "m1", otid: "o1", seqId: 10, runId: "r1" }));
+
+    // "Load older messages" lands while the run is still streaming.
+    acc.rebase({
+      messages: [
+        historyMessage({
+          id: "m1",
+          message_type: "assistant_message",
+          content: "Hel",
+          otid: "o1",
+          seq_id: 10,
+          run_id: "r1",
+        }),
+        historyMessage({
+          id: "m0",
+          message_type: "user_message",
+          content: "hi",
+          otid: "o0",
+          seq_id: 9,
+          run_id: "r1",
+        }),
+      ],
+    });
+
+    const rows = acc.apply(
+      assistant("lo", { uuid: "m1", otid: "o1", seqId: 11, runId: "r1" }),
+    );
+
+    expect(textRows(rows).map((row) => [row.kind, row.text])).toEqual([
+      ["user", "hi"],
+      ["assistant", "Hello"],
+    ]);
+  });
+
+  test("suppresses stream positions the backfilled page already proved", () => {
+    const acc = createTranscriptAccumulator();
+    acc.rebase([
+      historyMessage({
+        id: "m1",
+        message_type: "assistant_message",
+        content: "Hello",
+        otid: "o1",
+        seq_id: 11,
+        run_id: "r1",
+      }),
+    ]);
+
+    // A reconnect replays the deltas that produced the persisted message.
+    const rows = acc.apply(
+      assistant("lo", { uuid: "m1", otid: "o1", seqId: 11, runId: "r1" }),
+    );
+
+    expect((rows[0] as TranscriptTextRow).text).toBe("Hello");
+  });
+
+  test("orders backfilled rows ahead of live-only rows", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("live", { uuid: "m9", otid: "o9", seqId: 90, runId: "r2" }));
+    const rows = acc.rebase([
+      historyMessage({
+        id: "m1",
+        message_type: "user_message",
+        content: "older",
+        otid: "o1",
+        seq_id: 1,
+        run_id: "r1",
+      }),
+    ]);
+
+    expect(textRows(rows).map((row) => row.text)).toEqual(["older", "live"]);
+  });
+
+  test("merges history tool calls and returns onto the streamed tool row", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(toolCallFragment("call-1", '{"command":"ec', { uuid: "env-1" }));
+
+    const rows = acc.rebase([
+      historyMessage({
+        id: "hist-call",
+        message_type: "tool_call_message",
+        seq_id: 3,
+        run_id: "r1",
+        tool_call: {
+          tool_call_id: "call-1",
+          name: "Bash",
+          arguments: '{"command":"echo hi"}',
+        },
+      }),
+      historyMessage({
+        id: "hist-return",
+        message_type: "tool_return_message",
+        seq_id: 4,
+        run_id: "r1",
+        tool_call_id: "call-1",
+        tool_return: "hi",
+        status: "success",
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(toolRows(rows)[0]).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "Bash",
+      toolInput: { command: "echo hi" },
+      argumentsComplete: true,
+      status: "complete",
+      result: { content: "hi", isError: false },
+    });
+  });
+
+  test("maps approval requests onto the tool row", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.rebase([
+      historyMessage({
+        id: "hist-approval",
+        message_type: "approval_request_message",
+        tool_calls: [
+          {
+            tool_call_id: "call-2",
+            name: "Write",
+            arguments: '{"path":"a.txt"}',
+          },
+        ],
+      }),
+    ]);
+
+    expect(toolRows(rows)[0]).toMatchObject({
+      toolCallId: "call-2",
+      toolName: "Write",
+      toolInput: { path: "a.txt" },
+      status: "ready",
+    });
+  });
+
+  test("ignores history message types it does not own", () => {
+    const acc = createTranscriptAccumulator();
+    const rows = acc.rebase([
+      historyMessage({ id: "s1", message_type: "system_message", content: "sys" }),
+      historyMessage({
+        id: "e1",
+        message_type: "event_message",
+        event_type: "compaction",
+        event_data: {},
+      }),
+    ]);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  test("accepts an empty page without disturbing existing rows", () => {
+    const acc = createTranscriptAccumulator();
+    const before = acc.apply(
+      assistant("live", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }),
+    );
+    const after = acc.rebase({ messages: [] });
+
+    expect(after).toBe(before);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot behavior
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("snapshot behavior", () => {
+  test("produces a new array whenever a row changes", () => {
+    const acc = createTranscriptAccumulator();
+    const first = acc.apply(
+      assistant("a", { uuid: "m1", otid: "o1", seqId: 1, runId: "r1" }),
+    );
+    const second = acc.apply(
+      assistant("b", { uuid: "m1", otid: "o1", seqId: 2, runId: "r1" }),
+    );
+
+    expect(second).not.toBe(first);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  test("is exported from the package root", async () => {
+    const root = await import("../index.js");
+    expect(typeof root.createTranscriptAccumulator).toBe("function");
+    expect(root.createTranscriptAccumulator().rows()).toHaveLength(0);
+  });
+
+  test("reset() clears rows and replay state", () => {
+    const acc = createTranscriptAccumulator();
+    acc.apply(assistant("a", { uuid: "m1", otid: "o1", seqId: 5, runId: "r1" }));
+    acc.reset();
+
+    expect(acc.rows()).toHaveLength(0);
+    const rows = acc.apply(
+      assistant("a", { uuid: "m1", otid: "o1", seqId: 5, runId: "r1" }),
+    );
+    expect(textRows(rows).map((row) => row.text)).toEqual(["a"]);
+  });
+});

--- a/src/transcript-accumulator.ts
+++ b/src/transcript-accumulator.ts
@@ -1,0 +1,823 @@
+/**
+ * Transcript accumulator
+ *
+ * Turns an `SDKMessage` stream into stable, render-ready rows so consumers stop
+ * hand-rolling stream reconciliation. It owns the four reconciliation rules the
+ * wire protocol requires:
+ *
+ * 1. Typed-by-family accumulation. Text slices are keyed on
+ *    `message family + otid`, falling back to `uuid` *within the same family*.
+ *    A bare `otid`/`uuid` key would collapse an assistant slice into a
+ *    reasoning slice whenever a provider reuses an identifier across kinds.
+ * 2. Per-`runId` `seqId` replay suppression. Each run keeps its own high-water
+ *    mark, so a resumed stream that replays positions is dropped while a new
+ *    run starts from a clean threshold.
+ * 3. `toolCallId`-keyed merging. Tool argument fragments and the eventual tool
+ *    result merge into one row keyed on the payload identity (`toolCallId`),
+ *    while the envelope identities (the `uuid` of the `tool_call` message and
+ *    of the `tool_result` message) stay separately visible.
+ * 4. `rebase()` for mid-run backfill. A history page is merged in place with
+ *    replace semantics, reordered ahead of live-only rows, and raises the
+ *    replay thresholds it proves.
+ *
+ * The accumulator is pure and portable: no I/O, no timers, no Node built-ins,
+ * so it is exported from both the package root and `/client`.
+ */
+
+import type { Message as LettaMessage } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  extractTextFromContent,
+  firstToolCall,
+  firstToolReturn,
+} from "./remote-session-protocol.js";
+import { extractStreamTextDelta } from "./stream-events.js";
+import type { SDKMessage, SDKStreamEventMessage } from "./types.js";
+
+// ═══════════════════════════════════════════════════════════════
+// PUBLIC TYPES
+// ═══════════════════════════════════════════════════════════════
+
+/** Message families the accumulator projects into rows. */
+export type TranscriptRowKind = "user" | "assistant" | "reasoning" | "tool_call";
+
+/** Text families. Rows in different families never share a key. */
+export type TranscriptTextKind = "user" | "assistant" | "reasoning";
+
+export interface TranscriptRowIdentity {
+  /**
+   * Stable render key. Namespaced by message family, so a provider that reuses
+   * an `otid` or a message id across kinds still produces separate rows.
+   */
+  key: string;
+  /** Envelope id of the message that opened this row, when known. */
+  uuid?: string;
+  /** Lineage key for this typed slice, when the stream supplied one. */
+  otid?: string;
+  /** Run that most recently contributed to this row. */
+  runId?: string;
+  /** Highest replay cursor observed for this row. */
+  seqId?: number;
+}
+
+export interface TranscriptTextRow extends TranscriptRowIdentity {
+  kind: TranscriptTextKind;
+  /** Accumulated text for this slice. */
+  text: string;
+}
+
+export interface TranscriptToolResult {
+  content: string;
+  isError: boolean;
+  /**
+   * Envelope id of the `tool_result` message. Deliberately distinct from the
+   * row's `uuid`, which identifies the `tool_call` envelope.
+   */
+  uuid?: string;
+}
+
+/**
+ * Lifecycle of a tool row.
+ *
+ * - `streaming`: argument fragments are still arriving and have not parsed.
+ * - `ready`: arguments parsed; the result has not arrived.
+ * - `complete`: a tool result merged into the row.
+ */
+export type TranscriptToolCallStatus = "streaming" | "ready" | "complete";
+
+export interface TranscriptToolCallRow extends TranscriptRowIdentity {
+  kind: "tool_call";
+  /** Payload identity. This is what the row is keyed on. */
+  toolCallId: string;
+  toolName: string;
+  /**
+   * Best known parsed arguments. Never the transitional `{ raw }` wrapper the
+   * protocol layer emits for an argument fragment that does not parse.
+   */
+  toolInput: Record<string, unknown>;
+  /** Argument fragments concatenated in arrival order, when the wire sent any. */
+  rawArguments?: string;
+  /** Whether {@link toolInput} reflects fully parsed arguments. */
+  argumentsComplete: boolean;
+  result?: TranscriptToolResult;
+  status: TranscriptToolCallStatus;
+}
+
+export type TranscriptRow = TranscriptTextRow | TranscriptToolCallRow;
+
+/**
+ * A history page accepted by {@link TranscriptAccumulator.rebase}. Covers
+ * `session.listMessages()`, `session.bootstrapState()`, and a bare array of
+ * Letta API messages.
+ */
+export type TranscriptHistoryPage =
+  | { messages: readonly LettaMessage[] }
+  | readonly LettaMessage[];
+
+export interface TranscriptRebaseOptions {
+  /**
+   * Order of the supplied page. Omitted means auto-detect from `seq_id`/`date`;
+   * `listMessages()` defaults to `"desc"` (newest first).
+   */
+  order?: "asc" | "desc";
+}
+
+export interface TranscriptAccumulator {
+  /**
+   * Fold one streamed message into the transcript and return the current rows.
+   *
+   * The returned array is referentially stable when the message changed
+   * nothing (a replayed position, or a message family the accumulator ignores),
+   * so it can be handed straight to a memoizing renderer.
+   */
+  apply(message: SDKMessage): readonly TranscriptRow[];
+  /** Merge a history page into the transcript. Safe to call mid-run. */
+  rebase(
+    page: TranscriptHistoryPage,
+    options?: TranscriptRebaseOptions,
+  ): readonly TranscriptRow[];
+  /** Current rows in transcript order. */
+  rows(): readonly TranscriptRow[];
+  /** Drop all rows and replay state. */
+  reset(): void;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INTERNALS
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Key segment separator. Every key carries a family segment and an identifier
+ * kind segment ("otid"/"uuid"), so no wire identifier can produce a key that
+ * collides with a key from another family or another identifier kind.
+ */
+const SEP = ":";
+
+/** Bound on tracked replay thresholds so a long session cannot grow forever. */
+const MAX_TRACKED_RUNS = 64;
+
+/** Bucket used for streams that do not carry a `runId`. */
+const ANONYMOUS_RUN = "";
+
+interface TextSlice {
+  kind: TranscriptTextKind;
+  text: string;
+  uuid?: string;
+  otid?: string;
+  runId?: string;
+  seqId?: number;
+}
+
+function familyOtidAlias(kind: TranscriptTextKind, otid: string): string {
+  return `${kind}${SEP}otid${SEP}${otid}`;
+}
+
+function familyUuidAlias(kind: TranscriptTextKind, uuid: string): string {
+  return `${kind}${SEP}uuid${SEP}${uuid}`;
+}
+
+function toolRowKey(toolCallId: string): string {
+  return `tool_call${SEP}id${SEP}${toolCallId}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = record[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** Parse a JSON object, returning undefined for partial or non-object JSON. */
+function parseJsonObject(raw: string): Record<string, unknown> | undefined {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    return asRecord(JSON.parse(trimmed) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Detect the protocol layer's transitional `{ raw }` wrapper.
+ *
+ * `toolInputFromArguments()` wraps an unparseable argument fragment as
+ * `{ raw: "<fragment>" }`. That wrapper is a parse failure, not arguments, and
+ * must never overwrite previously parsed input.
+ */
+function isRawArgumentsWrapper(
+  input: Record<string, unknown> | undefined,
+  rawArguments: string | undefined,
+): boolean {
+  if (!input) return false;
+  const keys = Object.keys(input);
+  if (keys.length !== 1 || keys[0] !== "raw") return false;
+  const wrapped = input.raw;
+  if (typeof wrapped !== "string") return false;
+  return rawArguments === undefined || wrapped === rawArguments;
+}
+
+function toolStatus(row: {
+  argumentsComplete: boolean;
+  result?: TranscriptToolResult;
+}): TranscriptToolCallStatus {
+  if (row.result) return "complete";
+  return row.argumentsComplete ? "ready" : "streaming";
+}
+
+interface ToolCallMerge {
+  toolCallId: string;
+  toolName?: string;
+  toolInput?: Record<string, unknown>;
+  rawArguments?: string;
+  uuid?: string;
+  runId?: string;
+  seqId?: number;
+  /**
+   * `fragment` appends streamed argument text; `whole` treats the arguments as
+   * an authoritative complete value (history backfill).
+   */
+  mode: "fragment" | "whole";
+}
+
+interface ToolResultMerge {
+  toolCallId: string;
+  content: string;
+  isError: boolean;
+  uuid?: string;
+  runId?: string;
+  seqId?: number;
+}
+
+interface ToolArguments {
+  rawArguments?: string;
+  toolInput: Record<string, unknown>;
+  argumentsComplete: boolean;
+}
+
+/**
+ * Fold one argument delivery into the arguments known so far.
+ *
+ * The wire can deliver arguments three ways for the same call: streamed JSON
+ * fragments, one complete JSON string, or an already-decoded object. Only a
+ * successful parse is allowed to change `toolInput`.
+ */
+function mergeToolArguments(
+  previous: ToolArguments,
+  merge: ToolCallMerge,
+): ToolArguments {
+  let { rawArguments, toolInput, argumentsComplete } = previous;
+  const fragment = merge.rawArguments;
+  const wrapped = isRawArgumentsWrapper(merge.toolInput, fragment);
+
+  if (fragment !== undefined && fragment.length > 0) {
+    const whole = parseJsonObject(fragment);
+    if (whole) {
+      // A delivery that parses on its own is the complete argument value: a
+      // final non-chunked `tool_call_message`, or a backfilled history row.
+      // Replace rather than append so a repeated terminal message cannot
+      // corrupt the accumulation.
+      return { rawArguments: fragment, toolInput: whole, argumentsComplete: true };
+    }
+    if (argumentsComplete) {
+      // Arguments already parsed; a trailing partial (a replayed fragment after
+      // backfill) must not corrupt them.
+      return previous;
+    }
+    if (merge.mode === "whole") {
+      return { rawArguments: rawArguments ?? fragment, toolInput, argumentsComplete };
+    }
+    rawArguments = (rawArguments ?? "") + fragment;
+    const parsed = parseJsonObject(rawArguments);
+    if (parsed) {
+      return { rawArguments, toolInput: parsed, argumentsComplete: true };
+    }
+    // Keep the previous parse. Never promote the `{ raw }` wrapper.
+    return { rawArguments, toolInput, argumentsComplete: false };
+  }
+
+  if (!wrapped && merge.toolInput) {
+    const keys = Object.keys(merge.toolInput);
+    if (keys.length > 0) {
+      return { rawArguments, toolInput: merge.toolInput, argumentsComplete: true };
+    }
+    if (rawArguments === undefined) {
+      // Genuinely argument-free call: `{}` with no streamed fragments.
+      return { rawArguments, toolInput, argumentsComplete: true };
+    }
+  }
+
+  return previous;
+}
+
+class TranscriptAccumulatorImpl implements TranscriptAccumulator {
+  /** Row key -> row. Map insertion order is the transcript order. */
+  private byKey = new Map<string, TranscriptRow>();
+
+  /** `family + otid` -> row key. */
+  private aliasByOtid = new Map<string, string>();
+
+  /** `family + uuid` -> row key. */
+  private aliasByUuid = new Map<string, string>();
+
+  /** `runId` -> highest accepted `seqId` for that run. */
+  private seqThresholds = new Map<string, number>();
+
+  private snapshot: readonly TranscriptRow[] | null = null;
+
+  private anonymousCounter = 0;
+
+  apply(message: SDKMessage): readonly TranscriptRow[] {
+    switch (message.type) {
+      case "assistant":
+      case "reasoning":
+        this.applyText({
+          kind: message.type,
+          text: message.content,
+          uuid: message.uuid,
+          otid: typeof message.otid === "string" ? message.otid : undefined,
+          runId: message.runId,
+          seqId: message.seqId,
+        });
+        break;
+      case "tool_call":
+        this.mergeToolCall({
+          toolCallId: message.toolCallId,
+          toolName: message.toolName,
+          toolInput: message.toolInput,
+          rawArguments: message.rawArguments,
+          uuid: message.uuid,
+          runId: message.runId,
+          mode: "fragment",
+        });
+        break;
+      case "tool_result":
+        this.mergeToolResult({
+          toolCallId: message.toolCallId,
+          content: message.content,
+          isError: message.isError,
+          uuid: message.uuid,
+          runId: message.runId,
+        });
+        break;
+      case "stream_event":
+        this.applyStreamEvent(message);
+        break;
+      default:
+        // init/result/error/retry/queue_update/loop_status are turn-level
+        // signals rather than transcript content; consumers handle them
+        // directly.
+        break;
+    }
+    return this.rows();
+  }
+
+  rebase(
+    page: TranscriptHistoryPage,
+    options?: TranscriptRebaseOptions,
+  ): readonly TranscriptRow[] {
+    const messages = normalizeHistoryPage(page, options?.order);
+    if (messages.length === 0) return this.rows();
+
+    const historyKeys: string[] = [];
+    const seen = new Set<string>();
+    for (const message of messages) {
+      const key = this.applyHistoryMessage(message);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      historyKeys.push(key);
+    }
+
+    this.reorder(historyKeys);
+    return this.rows();
+  }
+
+  rows(): readonly TranscriptRow[] {
+    if (!this.snapshot) {
+      this.snapshot = Array.from(this.byKey.values());
+    }
+    return this.snapshot;
+  }
+
+  reset(): void {
+    this.byKey.clear();
+    this.aliasByOtid.clear();
+    this.aliasByUuid.clear();
+    this.seqThresholds.clear();
+    this.anonymousCounter = 0;
+    this.snapshot = null;
+  }
+
+  // ── replay suppression ────────────────────────────────────────
+
+  /**
+   * Per-run replay guard.
+   *
+   * Thresholds are bucketed by `runId`, so a brand new run starts with no
+   * threshold (a natural reset) while a resumed run keeps suppressing the
+   * positions it already delivered. Messages without a `seqId` are never
+   * suppressed here: their families are deduplicated by identity instead.
+   */
+  private isReplay(
+    runId: string | undefined,
+    seqId: number | undefined,
+  ): boolean {
+    if (seqId === undefined) return false;
+    const bucket = runId ?? ANONYMOUS_RUN;
+    const threshold = this.seqThresholds.get(bucket);
+    if (threshold !== undefined && seqId <= threshold) return true;
+    this.rememberSeq(bucket, seqId);
+    return false;
+  }
+
+  private rememberSeq(bucket: string, seqId: number): void {
+    const threshold = this.seqThresholds.get(bucket);
+    if (threshold !== undefined && threshold >= seqId) return;
+    this.seqThresholds.set(bucket, seqId);
+    while (this.seqThresholds.size > MAX_TRACKED_RUNS) {
+      const oldest = this.seqThresholds.keys().next();
+      if (oldest.done) break;
+      this.seqThresholds.delete(oldest.value);
+    }
+  }
+
+  // ── text families ─────────────────────────────────────────────
+
+  private applyText(slice: TextSlice): void {
+    if (this.isReplay(slice.runId, slice.seqId)) return;
+    this.writeText(slice, "append");
+  }
+
+  private writeText(slice: TextSlice, write: "append" | "replace"): string {
+    const key = this.resolveTextKey(slice.kind, slice.uuid, slice.otid);
+    const existing = this.byKey.get(key);
+    const previous =
+      existing && existing.kind === slice.kind ? existing : undefined;
+    this.setRow(key, {
+      kind: slice.kind,
+      key,
+      text: write === "append" ? (previous?.text ?? "") + slice.text : slice.text,
+      uuid: previous?.uuid ?? slice.uuid,
+      otid: slice.otid ?? previous?.otid,
+      runId: slice.runId ?? previous?.runId,
+      seqId: maxDefined(slice.seqId, previous?.seqId),
+    });
+    return key;
+  }
+
+  /**
+   * Resolve the row key for a text slice.
+   *
+   * `otid` is the lineage key when present, but a stream can transition: early
+   * fragments may carry only the message id and later fragments add an `otid`.
+   * Both identifiers are aliased to one row so the transition does not split
+   * it. When a message id is reused by a *second* slice carrying a different
+   * `otid` (a provider emitting `[text, thinking, text]` under one message id),
+   * the new `otid` opens its own row instead of appending to the previous one.
+   */
+  private resolveTextKey(
+    kind: TranscriptTextKind,
+    uuid: string | undefined,
+    otid: string | undefined,
+  ): string {
+    const otidAlias = otid ? familyOtidAlias(kind, otid) : undefined;
+    const uuidAlias = uuid ? familyUuidAlias(kind, uuid) : undefined;
+    const fromOtid = otidAlias ? this.aliasByOtid.get(otidAlias) : undefined;
+    const fromUuid = uuidAlias ? this.aliasByUuid.get(uuidAlias) : undefined;
+
+    let key: string | undefined = fromOtid ?? fromUuid;
+
+    if (key && !fromOtid && otid) {
+      const existing = this.byKey.get(key);
+      if (existing && existing.otid !== undefined && existing.otid !== otid) {
+        // The envelope already committed to a different lineage: this is a new
+        // slice sharing a message id, not a continuation of the old one.
+        key = undefined;
+      }
+    }
+
+    if (!key) {
+      key =
+        otidAlias ??
+        uuidAlias ??
+        `${kind}${SEP}auto${SEP}${++this.anonymousCounter}`;
+    }
+
+    if (otidAlias) this.aliasByOtid.set(otidAlias, key);
+    // The newest slice owns the envelope, so later id-only fragments continue
+    // it rather than the slice that closed before it.
+    if (uuidAlias) this.aliasByUuid.set(uuidAlias, key);
+
+    return key;
+  }
+
+  // ── tool families ─────────────────────────────────────────────
+
+  private mergeToolCall(merge: ToolCallMerge): string {
+    const key = toolRowKey(merge.toolCallId);
+    const existing = this.byKey.get(key);
+    const previous =
+      existing && existing.kind === "tool_call" ? existing : undefined;
+
+    const args = mergeToolArguments(
+      {
+        rawArguments: previous?.rawArguments,
+        toolInput: previous?.toolInput ?? {},
+        argumentsComplete: previous?.argumentsComplete ?? false,
+      },
+      merge,
+    );
+
+    const toolName =
+      merge.toolName && merge.toolName !== "?"
+        ? merge.toolName
+        : (previous?.toolName ?? merge.toolName ?? "?");
+
+    const next: TranscriptToolCallRow = {
+      kind: "tool_call",
+      key,
+      toolCallId: merge.toolCallId,
+      toolName,
+      toolInput: args.toolInput,
+      ...(args.rawArguments !== undefined
+        ? { rawArguments: args.rawArguments }
+        : {}),
+      argumentsComplete: args.argumentsComplete,
+      ...(previous?.result ? { result: previous.result } : {}),
+      status: "streaming",
+      // Envelope identity stays pinned to the `tool_call` message that opened
+      // the row; the payload identity is `toolCallId`.
+      uuid: previous?.uuid ?? merge.uuid,
+      runId: merge.runId ?? previous?.runId,
+      seqId: maxDefined(merge.seqId, previous?.seqId),
+    };
+    next.status = toolStatus(next);
+    this.setRow(key, next);
+    return key;
+  }
+
+  private mergeToolResult(merge: ToolResultMerge): string {
+    const key = toolRowKey(merge.toolCallId);
+    const existing = this.byKey.get(key);
+    const previous =
+      existing && existing.kind === "tool_call" ? existing : undefined;
+
+    this.setRow(key, {
+      kind: "tool_call",
+      key,
+      toolCallId: merge.toolCallId,
+      toolName: previous?.toolName ?? "?",
+      toolInput: previous?.toolInput ?? {},
+      ...(previous?.rawArguments !== undefined
+        ? { rawArguments: previous.rawArguments }
+        : {}),
+      argumentsComplete: previous?.argumentsComplete ?? false,
+      result: {
+        content: merge.content,
+        isError: merge.isError,
+        // The result envelope is a different message than the call envelope,
+        // so it is recorded beside the row's `uuid`, not over it.
+        ...(merge.uuid ? { uuid: merge.uuid } : {}),
+      },
+      status: "complete",
+      uuid: previous?.uuid,
+      runId: merge.runId ?? previous?.runId,
+      seqId: maxDefined(merge.seqId, previous?.seqId),
+    });
+    return key;
+  }
+
+  // ── raw stream events ─────────────────────────────────────────
+
+  /**
+   * Compose with {@link extractStreamTextDelta} for payloads the session layer
+   * passes through uncooked.
+   *
+   * Identity comes from the payload when it has any (`id`, `otid`, `seq_id`,
+   * `run_id`). Content-block deltas carry none, so they fold into a single live
+   * row per family — the most an anonymous delta stream can support.
+   */
+  private applyStreamEvent(message: SDKStreamEventMessage): void {
+    const delta = extractStreamTextDelta(message.event);
+    if (!delta) return;
+    const payload = asRecord(message.event);
+    const otid = payload ? readString(payload, "otid") : undefined;
+    const payloadId = payload ? readString(payload, "id") : undefined;
+    const identified = otid !== undefined || payloadId !== undefined;
+
+    this.applyText({
+      kind: delta.kind,
+      text: delta.text,
+      uuid: identified ? payloadId : `${delta.kind}${SEP}live`,
+      otid,
+      runId: payload ? readString(payload, "run_id") : undefined,
+      seqId: payload ? readNumber(payload, "seq_id") : undefined,
+    });
+  }
+
+  // ── history backfill ──────────────────────────────────────────
+
+  private applyHistoryMessage(message: LettaMessage): string | undefined {
+    const record = asRecord(message);
+    if (!record) return undefined;
+    const messageType = readString(record, "message_type");
+    if (!messageType) return undefined;
+
+    const uuid = readString(record, "id");
+    const otid = readString(record, "otid");
+    const runId = readString(record, "run_id");
+    const seqId = readNumber(record, "seq_id");
+
+    // A history page proves every position up to its own cursor for that run,
+    // so replayed deltas at or below it are suppressed after the merge.
+    if (seqId !== undefined) {
+      this.rememberSeq(runId ?? ANONYMOUS_RUN, seqId);
+    }
+
+    switch (messageType) {
+      case "user_message":
+      case "assistant_message": {
+        const text = extractTextFromContent(record.content);
+        if (text === null) return undefined;
+        return this.writeText(
+          {
+            kind: messageType === "user_message" ? "user" : "assistant",
+            text,
+            uuid,
+            otid,
+            runId,
+            seqId,
+          },
+          "replace",
+        );
+      }
+      case "reasoning_message": {
+        const text =
+          typeof record.reasoning === "string"
+            ? record.reasoning
+            : extractTextFromContent(record.content);
+        if (text === null || text === undefined) return undefined;
+        return this.writeText(
+          { kind: "reasoning", text, uuid, otid, runId, seqId },
+          "replace",
+        );
+      }
+      case "tool_call_message":
+      case "approval_request_message": {
+        const toolCall = firstToolCall(record);
+        if (!toolCall) return undefined;
+        const fn = asRecord(toolCall.function);
+        const toolCallId =
+          (typeof toolCall.tool_call_id === "string"
+            ? toolCall.tool_call_id
+            : undefined) ??
+          (typeof toolCall.id === "string" ? toolCall.id : undefined);
+        if (!toolCallId) return undefined;
+        const args = toolCall.arguments ?? fn?.arguments;
+        return this.mergeToolCall({
+          toolCallId,
+          toolName:
+            (typeof toolCall.name === "string" ? toolCall.name : undefined) ??
+            (typeof fn?.name === "string" ? fn.name : undefined),
+          toolInput: asRecord(args),
+          rawArguments: typeof args === "string" ? args : undefined,
+          uuid,
+          runId,
+          seqId,
+          mode: "whole",
+        });
+      }
+      case "tool_return_message": {
+        const toolReturn = firstToolReturn(record) ?? record;
+        const toolCallId =
+          readString(record, "tool_call_id") ??
+          (typeof toolReturn.tool_call_id === "string"
+            ? toolReturn.tool_call_id
+            : undefined);
+        if (!toolCallId) return undefined;
+        const content =
+          extractTextFromContent(
+            record.tool_return ?? toolReturn.tool_return ?? toolReturn.content,
+          ) ?? "";
+        const status =
+          readString(record, "status") ??
+          (typeof toolReturn.status === "string"
+            ? toolReturn.status
+            : undefined);
+        return this.mergeToolResult({
+          toolCallId,
+          content,
+          isError: status === "error",
+          uuid,
+          runId,
+          seqId,
+        });
+      }
+      default:
+        // system/summary/event/hidden-reasoning/approval-response messages are
+        // not transcript content this accumulator claims to own.
+        return undefined;
+    }
+  }
+
+  // ── row bookkeeping ───────────────────────────────────────────
+
+  private setRow(key: string, row: TranscriptRow): void {
+    this.byKey.set(key, row);
+    this.snapshot = null;
+  }
+
+  /** Move backfilled rows ahead of rows that only exist in the live stream. */
+  private reorder(historyKeys: readonly string[]): void {
+    if (historyKeys.length === 0) return;
+    const historySet = new Set(historyKeys);
+    const reordered = new Map<string, TranscriptRow>();
+    for (const key of historyKeys) {
+      const row = this.byKey.get(key);
+      if (row) reordered.set(key, row);
+    }
+    for (const [key, row] of this.byKey) {
+      if (historySet.has(key)) continue;
+      reordered.set(key, row);
+    }
+    this.byKey = reordered;
+    this.snapshot = null;
+  }
+}
+
+function maxDefined(
+  next: number | undefined,
+  previous: number | undefined,
+): number | undefined {
+  if (next === undefined) return previous;
+  if (previous === undefined) return next;
+  return Math.max(next, previous);
+}
+
+function normalizeHistoryPage(
+  page: TranscriptHistoryPage,
+  order: "asc" | "desc" | undefined,
+): readonly LettaMessage[] {
+  const messages = Array.isArray(page)
+    ? (page as readonly LettaMessage[])
+    : ((page as { messages?: readonly LettaMessage[] }).messages ?? []);
+  if (messages.length < 2) return messages;
+  const descending = order ? order === "desc" : detectDescending(messages);
+  return descending ? [...messages].reverse() : messages;
+}
+
+/**
+ * `listMessages()` defaults to newest-first. Detect that from the page itself
+ * so callers do not have to restate the order they requested.
+ */
+function detectDescending(messages: readonly LettaMessage[]): boolean {
+  const seqIds: number[] = [];
+  const dates: number[] = [];
+  for (const message of messages) {
+    const record = asRecord(message);
+    if (!record) continue;
+    const seqId = readNumber(record, "seq_id");
+    if (seqId !== undefined) seqIds.push(seqId);
+    const date = readString(record, "date");
+    if (!date) continue;
+    const parsed = Date.parse(date);
+    if (!Number.isNaN(parsed)) dates.push(parsed);
+  }
+  const ordered = seqIds.length >= 2 ? seqIds : dates;
+  if (ordered.length < 2) return false;
+  const first = ordered[0] as number;
+  const last = ordered[ordered.length - 1] as number;
+  return last < first;
+}
+
+/**
+ * Create a transcript accumulator.
+ *
+ * @example
+ * ```typescript
+ * const acc = createTranscriptAccumulator();
+ * for await (const message of session.stream()) {
+ *   render(acc.apply(message));
+ * }
+ *
+ * // Safe mid-run: merges older history without duplicating live rows.
+ * acc.rebase(await session.listMessages({ limit: 50 }));
+ * ```
+ */
+export function createTranscriptAccumulator(): TranscriptAccumulator {
+  return new TranscriptAccumulatorImpl();
+}


### PR DESCRIPTION
Closes #269.

## Problem

The SDK exports exactly one streaming helper — `extractStreamTextDelta`, which turns a single payload into `{kind, text}`. Nothing turns a stream into rows, so every consumer re-derives the same reconciliation rules, and `grep -rn "seqId\|otid" src/*.ts` confirms the SDK is a pure read-and-forward pass-through. Our own reference React demo merges fragments **by array position**, which holds only while there is one stream per turn, no replay, and no mid-run backfill — none of which are stated invariants.

## What this adds

`createTranscriptAccumulator()` in `src/transcript-accumulator.ts`, exported from **both** the package root and the portable `/client` entry (browser and React Native consumers need it most). It is pure: no I/O, no timers, no Node built-ins.

```ts
import { createTranscriptAccumulator } from "@letta-ai/letta-agent-sdk";
// or "@letta-ai/letta-agent-sdk/client"

const transcript = createTranscriptAccumulator();

for await (const message of session.stream()) {
  render(transcript.apply(message));       // readonly TranscriptRow[]
}

transcript.rebase(await session.listMessages({ limit: 50 }));  // safe mid-run
```

### API shape

```ts
interface TranscriptAccumulator {
  apply(message: SDKMessage): readonly TranscriptRow[];
  rebase(page: TranscriptHistoryPage, options?: { order?: "asc" | "desc" }): readonly TranscriptRow[];
  rows(): readonly TranscriptRow[];
  reset(): void;
}

type TranscriptRow = TranscriptTextRow | TranscriptToolCallRow;
// TranscriptTextRow:     { kind: "user" | "assistant" | "reasoning"; key; text; uuid?; otid?; runId?; seqId? }
// TranscriptToolCallRow: { kind: "tool_call"; key; toolCallId; toolName; toolInput; rawArguments?;
//                          argumentsComplete; result?: { content; isError; uuid? };
//                          status: "streaming" | "ready" | "complete"; uuid?; runId?; seqId? }
```

## Design

**Typed-by-family keying.** Text rows are keyed on `message family + otid`, falling back to `uuid` *within the family only*. Family-namespaced alias maps (`aliasByOtid`, `aliasByUuid`) also handle the `id <-> otid` transitional states that letta-code's `src/cli/helpers/accumulator.ts` handles: a stream that starts id-only and later adds an `otid` stays one row, while a *second* `otid` arriving under an already-committed message id opens its own row (the Anthropic `[text, thinking, text]` shape). A bare `otid` key would collapse an assistant slice into a reasoning slice the moment a provider reuses an identifier across kinds.

**Per-run replay suppression.** `seqId` high-water marks are bucketed by `runId`. A new run has no bucket, which *is* the reset; a resumed run keeps suppressing the positions it already delivered, even after a newer run has started. Messages without a `seqId` are never suppressed here — their families deduplicate by identity instead. The bucket map is capped at 64 runs.

**Tool merging.** Tool rows are keyed on the payload identity (`toolCallId`). The envelope identities stay separately readable: `row.uuid` is the `tool_call` envelope, `row.result.uuid` is the `tool_result` envelope. Argument deliveries fold through one function that only lets a **successful parse** change `toolInput`: a delivery that parses on its own replaces (a final non-chunked message or a backfilled row cannot be corrupted by re-delivery), otherwise fragments concatenate and re-parse. The protocol layer's transitional `{ raw }` wrapper from `toolInputFromArguments()` is recognized as a parse failure, never promoted into `toolInput`, and a partial fragment arriving after arguments already parsed is discarded rather than appended.

**`rebase()` for backfill.** Accepts `listMessages()`, `bootstrapState()`, or a bare message array; auto-detects newest-first ordering from `seq_id`/`date` (overridable). History merges with *replace* semantics (history rows are whole messages, stream slices are deltas), matching rows land on their existing keys instead of duplicating, backfilled rows are ordered ahead of live-only rows, and the page raises the replay thresholds it proves — so deltas the persisted message already contains are suppressed if a reconnect replays them.

**Composes with `extractStreamTextDelta`.** `stream_event` messages route through it, taking identity from the payload (`id`, `otid`, `seq_id`, `run_id`) when present. Fully anonymous `content_block_delta` payloads fold into one live row per family, which is the most an identifier-free delta stream can support.

## API-shape decisions

- **`apply()` returns the full ordered snapshot**, not a diff, matching the issue's sketch. The array is *referentially stable* when nothing changed (a suppressed replay, or a turn-level message), and rows are replaced immutably on change, so `React.memo`/`useSyncExternalStore` consumers get correct identity semantics for free.
- **Row kinds are limited to `user`, `assistant`, `reasoning`, `tool_call`.** Turn-level messages (`init`, `result`, `error`, `retry`, `queue_update`, `loop_status`) and non-content history types (system/summary/event/hidden-reasoning/approval-response) are deliberately not rows; they are control signals a consumer handles directly. Easy to widen later, hard to narrow.
- **Types live in `src/transcript-accumulator.ts`, not `types.ts`.** They are public and re-exported from both entries, but `types.ts` is at 1297 of its documented 1350-line ceiling and these types are meaningless away from their implementation.
- **No constructor options.** Nothing here is a policy choice a caller should have to make; `rebase()` takes the only real knob (`order`).
- **`rebase()` does not clear rows.** It merges. A caller who wants a hard reload calls `reset()` first.

## Verification

- `bun run check` — passes (typecheck + source-size budgets; `transcript-accumulator.ts` is 823 lines against the 900 default).
- `bun test` — 251 pass, 11 skip, 0 fail (up from 216 pass on `main`).
- `bun run build` — passes, including the portable-build guard that rejects Node built-ins in the `/client` graph; both `dist/index.js` and `dist/client-entry.js` export the factory.
- 34 new tests in `src/tests/transcript-accumulator.test.ts`, including the adversarial cases: a provider reusing one `otid` across assistant and reasoning, `uuid` collision across families, id-only → id+otid transition, a second `otid` under a committed message id, replayed `seqId`s after a resume, a new run resetting the threshold, an older run still suppressed after a newer one starts, tool args in fragments then a `tool_result`, a partial fragment after parsed args, backfill mid-stream then continued fragments, and backfill-proved positions suppressing replayed deltas.
- Live integration tests were not run (they need credentials).

Untouched by design, to avoid conflicting with the other in-flight SDK changes: `AGENTS.md`, and the `send()` / `SendMessage` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)