### PR TITLE
fix: preserve remote turn outcome semantics

### DIFF
--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -51,6 +51,7 @@ export type RuntimeTurnResult = {
   success?: boolean;
   detail?: string;
   errorCode?: SDKErrorCode;
+  recoverable?: boolean;
 };
 
 export type RuntimeSendTurnOptions = {
@@ -491,6 +492,21 @@ export function loopStatusRunIds(message: ProtocolMessage): string[] {
   return Array.isArray(activeRunIds)
     ? activeRunIds.filter((runId): runId is string => typeof runId === "string")
     : [];
+}
+
+export function turnFinishedRecord(message: ProtocolMessage): {
+  runId?: string;
+  stopReason: string;
+  error?: string;
+} | null {
+  if (message.type !== "turn_finished" || typeof message.stop_reason !== "string") {
+    return null;
+  }
+  return {
+    ...(typeof message.run_id === "string" ? { runId: message.run_id } : {}),
+    stopReason: message.stop_reason,
+    ...(typeof message.error === "string" ? { error: message.error } : {}),
+  };
 }
 
 export function queueItems(message: ProtocolMessage): SDKQueueItem[] {

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -143,13 +143,10 @@ export type TurnTracker = {
   timeout: ReturnType<typeof setTimeout> | null;
 };
 
-export const FAILURE_STOP_REASONS = new Set([
-  "error",
-  "llm_api_error",
-  "max_steps",
-  "interrupted",
-  "cancelled",
-  "canceled",
+const SUCCESS_STOP_REASONS = new Set([
+  "end_turn",
+  "tool_rule",
+  "requires_approval",
 ]);
 const REASONING_EFFORTS = new Set<ReasoningEffort>([
   "none",
@@ -224,6 +221,10 @@ export function toSdkErrorCode(value: string | null | undefined): SDKErrorCode |
   return KNOWN_SDK_ERROR_CODES.has(value as SDKErrorCode)
     ? (value as SDKErrorCode)
     : undefined;
+}
+
+export function isFailureStopReason(value: string | null | undefined): boolean {
+  return value != null && !SUCCESS_STOP_REASONS.has(value);
 }
 
 function isReasoningEffort(value: unknown): value is ReasoningEffort {

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -1,4 +1,5 @@
 import type {
+  SDKErrorCode,
   SDKLoopStatusMessage,
   SDKMessage,
   SDKQueueUpdateMessage,
@@ -27,6 +28,7 @@ import {
   toSdkErrorCode,
   toSessionDeviceStatus,
   toolInputFromArguments,
+  turnFinishedRecord,
   type ProtocolMessage,
   type RuntimeScope,
   type RuntimeTurnResult,
@@ -146,6 +148,12 @@ export class RemoteTurnCoordinator {
       return;
     }
 
+    const finished = turnFinishedRecord(message);
+    if (finished) {
+      this.handleTurnFinished(finished);
+      return;
+    }
+
     const delta = streamDeltaRecord(message);
     if (!delta) return;
     const active = this.activateNextTurnFromProtocol();
@@ -182,15 +190,18 @@ export class RemoteTurnCoordinator {
     if (this.closed) return;
     const active = this.activeTurn;
     if (active) {
-      this.failTurn(active, detail);
+      this.failTurn(active, detail, {
+        errorCode: "stream_closed",
+        recoverable: true,
+      });
     } else {
       this.enqueue({
         type: "error",
         message: detail,
-        errorCode: "error",
-        stopReason: "error",
+        errorCode: "stream_closed",
+        stopReason: "stream_closed",
         errorDetail: detail,
-        recoverable: false,
+        recoverable: true,
       });
     }
     this.close();
@@ -228,23 +239,29 @@ export class RemoteTurnCoordinator {
     return next;
   }
 
-  private failTurn(turn: TurnTracker, detail: string): void {
+  private failTurn(
+    turn: TurnTracker,
+    detail: string,
+    options: { errorCode?: SDKErrorCode; recoverable?: boolean } = {},
+  ): void {
     if (this.activeTurn !== turn) return;
+    const errorCode = options.errorCode ?? "error";
     this.enqueue({
       type: "error",
       message: detail,
-      errorCode: "error",
-      stopReason: "error",
+      errorCode,
+      stopReason: errorCode,
       errorDetail: detail,
-      recoverable: false,
+      recoverable: options.recoverable ?? false,
     });
     this.completeActiveTurn({
       runtime: turn.runtime,
-      stopReason: "error",
+      stopReason: errorCode,
       runIds: [...turn.runIds],
       success: false,
       detail,
-      errorCode: "error",
+      errorCode,
+      recoverable: options.recoverable,
     });
   }
 
@@ -306,6 +323,36 @@ export class RemoteTurnCoordinator {
         runIds: [...active.runIds],
       });
     }
+  }
+
+  private handleTurnFinished(finished: {
+    runId?: string;
+    stopReason: string;
+    error?: string;
+  }): void {
+    const active = this.activeTurn;
+    if (!active || !finished.runId) return;
+    if (
+      active.runIds.size > 0 &&
+      !active.runIds.has(finished.runId)
+    ) {
+      return;
+    }
+    active.runIds.add(finished.runId);
+    if (finished.stopReason === "requires_approval") {
+      active.observedRequiresApprovalStop = true;
+      return;
+    }
+    const errorCode = toSdkErrorCode(finished.stopReason);
+    const success = !FAILURE_STOP_REASONS.has(finished.stopReason);
+    this.completeActiveTurn({
+      runtime: active.runtime,
+      stopReason: finished.stopReason,
+      runIds: [...active.runIds],
+      success,
+      ...(success ? {} : { errorCode: errorCode ?? "error" }),
+      ...(finished.error ? { detail: finished.error } : {}),
+    });
   }
 
   private handleTurnTerminalDelta(
@@ -538,7 +585,11 @@ export class RemoteTurnCoordinator {
       error: success ? undefined : (errorCode ?? stopReason ?? "error"),
       errorCode: success ? undefined : (errorCode ?? "error"),
       approvalConflict: approvalConflict || undefined,
-      recoverable: approvalConflict ? true : success ? undefined : false,
+      recoverable: approvalConflict
+        ? true
+        : success
+          ? undefined
+          : (turn.recoverable ?? false),
       errorDetail: success ? undefined : turn.detail,
       stopReason,
       durationMs:

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -8,12 +8,12 @@ import type {
   SessionDeviceStatus,
 } from "./types.js";
 import {
-  FAILURE_STOP_REASONS,
   deviceStatusRecord,
   extractTextFromContent,
   firstToolCall,
   firstToolReturn,
   isApprovalConflictSignal,
+  isFailureStopReason,
   loopStatusRunIds,
   loopStatusValue,
   normalizeCallerOtid,
@@ -42,6 +42,8 @@ type RemoteTurnCoordinatorConfig = {
   onDeviceStatus(status: SessionDeviceStatus): void;
 };
 
+const MAX_RECENTLY_SETTLED_RUN_IDS = 256;
+
 /**
  * Owns the portable session's turn correlation and stream queue.
  *
@@ -58,6 +60,7 @@ export class RemoteTurnCoordinator {
   private streamResolvers: Array<(message: SDKMessage | null) => void> = [];
   private activeTurn: TurnTracker | null = null;
   private pendingTurns: TurnTracker[] = [];
+  private settledRunIds = new Set<string>();
   private nextTurnId = 0;
   private messageCounter = 0;
   private clientMessageCounter = 0;
@@ -272,8 +275,20 @@ export class RemoteTurnCoordinator {
       clearTimeout(active.timeout);
       active.timeout = null;
     }
+    this.rememberSettledRunIds(active.runIds);
     this.enqueue(this.resultFromTurn(turn, active));
     this.activeTurn = null;
+  }
+
+  private rememberSettledRunIds(runIds: Iterable<string>): void {
+    for (const runId of runIds) {
+      if (!runId || this.settledRunIds.has(runId)) continue;
+      this.settledRunIds.add(runId);
+      if (this.settledRunIds.size > MAX_RECENTLY_SETTLED_RUN_IDS) {
+        const expired = this.settledRunIds.values().next().value;
+        if (expired) this.settledRunIds.delete(expired);
+      }
+    }
   }
 
   private handleLoopStatusMessage(message: ProtocolMessage): void {
@@ -332,6 +347,7 @@ export class RemoteTurnCoordinator {
   }): void {
     const active = this.activeTurn;
     if (!active || !finished.runId) return;
+    if (this.settledRunIds.has(finished.runId)) return;
     if (
       active.runIds.size > 0 &&
       !active.runIds.has(finished.runId)
@@ -344,7 +360,7 @@ export class RemoteTurnCoordinator {
       return;
     }
     const errorCode = toSdkErrorCode(finished.stopReason);
-    const success = !FAILURE_STOP_REASONS.has(finished.stopReason);
+    const success = !isFailureStopReason(finished.stopReason);
     this.completeActiveTurn({
       runtime: active.runtime,
       stopReason: finished.stopReason,
@@ -572,8 +588,8 @@ export class RemoteTurnCoordinator {
       turn.success !== undefined
         ? turn.success &&
           !approvalConflict &&
-          !FAILURE_STOP_REASONS.has(stopReason ?? "")
-        : !approvalConflict && !FAILURE_STOP_REASONS.has(stopReason ?? "");
+          !isFailureStopReason(stopReason)
+        : !approvalConflict && !isFailureStopReason(stopReason);
     const errorCode = approvalConflict
       ? "approval_conflict"
       : (turn.errorCode ?? toSdkErrorCode(stopReason));

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -357,6 +357,13 @@ export class RemoteTurnCoordinator {
     active.runIds.add(finished.runId);
     if (finished.stopReason === "requires_approval") {
       active.observedRequiresApprovalStop = true;
+      if (!this.autoHandlesToolApprovals) {
+        this.completeActiveTurn({
+          runtime: active.runtime,
+          stopReason: finished.stopReason,
+          runIds: [...active.runIds],
+        });
+      }
       return;
     }
     const errorCode = toSdkErrorCode(finished.stopReason);

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1195,12 +1195,15 @@ describe("LettaAgentClient", () => {
 
         expect(messages[0]).toMatchObject({
           type: "error",
-          stopReason: "error",
+          stopReason: "stream_closed",
+          errorCode: "stream_closed",
+          recoverable: true,
         });
         expect(messages.at(-1)).toMatchObject({
           type: "result",
           success: false,
-          errorCode: "error",
+          errorCode: "stream_closed",
+          recoverable: true,
         });
       } finally {
         FakeAppServerSocket.inputScenario = "normal";

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1519,12 +1519,15 @@ describe("CloudEnvironmentSession", () => {
 
       expect(messages[0]).toMatchObject({
         type: "error",
-        stopReason: "error",
+        stopReason: "stream_closed",
+        errorCode: "stream_closed",
+        recoverable: true,
       });
       expect(messages.at(-1)).toMatchObject({
         type: "result",
         success: false,
-        errorCode: "error",
+        errorCode: "stream_closed",
+        recoverable: true,
       });
       await expect(session.send("do not replay")).rejects.toThrow("Session is closed");
       const inputs = FakeCloudSocket.allSent().filter((command) => {

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -97,7 +97,7 @@ describe("remote turn terminal receipts", () => {
     conversation_id: "conv-1",
   };
 
-  test("uses turn_finished as the authoritative successful terminal", async () => {
+  test("uses a correlated turn_finished receipt as a successful terminal", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",
       onDeviceStatus: () => {},
@@ -133,6 +133,80 @@ describe("remote turn terminal receipts", () => {
       result: "done",
       stopReason: "end_turn",
       runIds: ["run-1"],
+    });
+    coordinator.close();
+  });
+
+  test("does not apply a settled run receipt to the next tracked turn", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "first",
+        run_id: "run-1",
+        id: "message-1",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-1",
+      }),
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      runIds: ["run-1"],
+    });
+
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-1",
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "second",
+        run_id: "run-2",
+        id: "message-2",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-2",
+        run_id: "run-2",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "second",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "second",
+      runIds: ["run-2"],
     });
     coordinator.close();
   });
@@ -198,6 +272,45 @@ describe("remote turn terminal receipts", () => {
 
     expect(coordinator.hasInFlightTurn()).toBe(true);
     coordinator.close();
+  });
+
+  test("classifies terminal failure receipts as failed results", async () => {
+    const stopReasons = [
+      "invalid_llm_response",
+      "invalid_tool_call",
+      "max_tokens_exceeded",
+      "no_tool_call",
+      "insufficient_credits",
+      "context_window_overflow_in_system_prompt",
+    ];
+
+    for (const stopReason of stopReasons) {
+      const coordinator = new RemoteTurnCoordinator({
+        label: "test",
+        onDeviceStatus: () => {},
+      });
+      coordinator.trackSentTurn(runtime);
+      coordinator.handleProtocolMessage(
+        {
+          type: "turn_finished",
+          runtime,
+          turn_id: `turn-${stopReason}`,
+          run_id: `run-${stopReason}`,
+          stop_reason: stopReason,
+          error: "terminal failure",
+        },
+        runtime,
+      );
+
+      expect(await coordinator.nextMessage()).toMatchObject({
+        type: "result",
+        success: false,
+        errorCode: "error",
+        errorDetail: "terminal failure",
+        stopReason,
+      });
+      coordinator.close();
+    }
   });
 
   test("reports active transport loss as a recoverable unknown outcome", async () => {

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -188,6 +188,81 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("terminalizes a manual approval when turn_finished follows loop status", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_APPROVAL",
+          active_run_ids: ["run-approval"],
+        },
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-approval",
+        run_id: "run-approval",
+        stop_reason: "requires_approval",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "loop_status",
+      status: "WAITING_ON_APPROVAL",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: false,
+      approvalConflict: true,
+      stopReason: "requires_approval",
+      runIds: ["run-approval"],
+    });
+    coordinator.close();
+  });
+
+  test("keeps an auto-handled approval open when turn_finished follows loop status", () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      autoHandlesToolApprovals: true,
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_APPROVAL",
+          active_run_ids: ["run-approval"],
+        },
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-approval",
+        run_id: "run-approval",
+        stop_reason: "requires_approval",
+      },
+      runtime,
+    );
+
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.close();
+  });
+
   test("does not apply a settled run receipt to the next tracked turn", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -91,6 +91,148 @@ describe("cooked stream message identity", () => {
   });
 });
 
+describe("remote turn terminal receipts", () => {
+  const runtime: RuntimeScope = {
+    agent_id: "agent-1",
+    conversation_id: "conv-1",
+  };
+
+  test("uses turn_finished as the authoritative successful terminal", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "done",
+        run_id: "run-1",
+        id: "message-1",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-1",
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "done",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "done",
+      stopReason: "end_turn",
+      runIds: ["run-1"],
+    });
+    coordinator.close();
+  });
+
+  test("ignores a turn_finished receipt for a different active run", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "running",
+        run_id: "run-1",
+        id: "message-1",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        run_id: "run-other",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      runIds: ["run-1"],
+    });
+    coordinator.close();
+  });
+
+  test("ignores an uncorrelated turn_finished without a run id", () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.close();
+  });
+
+  test("reports active transport loss as a recoverable unknown outcome", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "partial",
+        run_id: "run-1",
+        id: "message-1",
+      }),
+      runtime,
+    );
+    coordinator.closeWithError("connection dropped");
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "error",
+      errorCode: "stream_closed",
+      recoverable: true,
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: false,
+      errorCode: "stream_closed",
+      recoverable: true,
+      runIds: ["run-1"],
+    });
+  });
+});
+
 function streamDelta(
   runtime: RuntimeScope,
   delta: Record<string, unknown>,

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -137,6 +137,57 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("accepts turn_finished as the first run evidence", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-receipt-only",
+        run_id: "run-receipt-only",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      runIds: ["run-receipt-only"],
+    });
+    coordinator.close();
+  });
+
+  test("classifies tool_rule as a successful terminal", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-tool-rule",
+        run_id: "run-tool-rule",
+        stop_reason: "tool_rule",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      stopReason: "tool_rule",
+      runIds: ["run-tool-rule"],
+    });
+    coordinator.close();
+  });
+
   test("does not apply a settled run receipt to the next tracked turn", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",


### PR DESCRIPTION
## Summary

- use correlated `turn_finished` receipts when the stream terminal is missing
- ignore receipts from settled runs and mismatched active runs
- classify unknown terminal stop reasons as failures
- report active transport loss as recoverable `stream_closed` uncertainty

## Why

A Cloud run can persist a complete response after the SDK transport drops. The SDK must preserve that unknown delivery state without applying a delayed receipt to a later turn.

Terminal receipts also carry stop reasons that were absent from the SDK failure list. These reasons must not produce successful results.

## Verification

- `bun test` (263 passed, 11 live tests skipped, 0 failed)
- `bun run check`
- `bun run build`
- independent review of commit `00358e1`

👾 Generated with [Letta Code](https://letta.com)
