### PR TITLE
feat: expose terminal-result session helper

### DIFF
--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -93,10 +93,6 @@ function looksLikeConversationId(id: string): boolean {
   return id.startsWith("conv-") || id.startsWith("local-conv-");
 }
 
-type OneShotSession = LettaCodeSession & {
-  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
-};
-
 /**
  * Top-level Letta Agent SDK client.
  *
@@ -348,7 +344,7 @@ export class LettaAgentClientBase {
     const session = this.createSession(agentId, options);
 
     try {
-      return await (session as OneShotSession).sendAndWaitForResult(message);
+      return await session.sendAndWaitForResult(message);
     } finally {
       session.close();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,10 +288,11 @@ export function resumeSession(
 /**
  * One-shot convenience for scripts, smoke tests, and evals.
  *
- * Creates a short-lived conversation, waits for the final result, and closes
- * the session. Applications that need streaming, approvals, cancellation,
- * queueing, or continued interaction should use createSession() with send()
- * and stream() instead.
+ * Creates a new conversation on the agent, waits for the final result, and
+ * closes the short-lived session. The conversation remains persisted.
+ * Applications that need streaming, approvals, cancellation, queueing, or
+ * continued interaction should use createSession() with send() and stream()
+ * instead.
  *
  * @example
  * ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,10 +298,6 @@ export function resumeSession(
  * const result = await prompt('What is the capital of France?', agentId);  // specific agent
  * ```
  */
-type OneShotSession = LettaCodeSession & {
-  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
-};
-
 type InitializableSession = LettaCodeSession & {
   initialize(): Promise<SDKInitMessage>;
 };
@@ -314,7 +310,7 @@ export async function prompt(
   const session = createSession(agentId, options);
 
   try {
-    return await (session as OneShotSession).sendAndWaitForResult(message);
+    return await session.sendAndWaitForResult(message);
   } finally {
     session.close();
   }

--- a/src/tests/advanced-session.ts
+++ b/src/tests/advanced-session.ts
@@ -1,13 +1,7 @@
-import type {
-  LettaCodeSession,
-  SDKInitMessage,
-  SDKResultMessage,
-  SendMessage,
-} from "../types.js";
+import type { LettaCodeSession, SDKInitMessage } from "../types.js";
 
 export type AdvancedSession = LettaCodeSession & {
   initialize(): Promise<SDKInitMessage>;
-  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
   updateToolset(toolsetPreference: string): Promise<void>;
 };
 

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -973,7 +973,7 @@ describe("LettaAgentClient", () => {
       expect(init.agentId).toBe("agent-123");
       expect(init.conversationId).toBe("conv-created");
 
-      const result = await asAdvanced(session).sendAndWaitForResult("hello");
+      const result = await session.sendAndWaitForResult("hello");
       expect(result.success).toBe(true);
       expect(result.result).toBe("hello from app-server");
       expect(result.runIds).toEqual(["run-1"]);
@@ -1008,6 +1008,28 @@ describe("LettaAgentClient", () => {
     }
   });
 
+  test("sendAndWaitForResult rejects while another turn is in flight", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "hang";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("conv-existing");
+    try {
+      await session.send("first message");
+
+      await expect(
+        session.sendAndWaitForResult("second message"),
+      ).rejects.toThrow("A turn is already in flight");
+    } finally {
+      FakeAppServerSocket.inputScenario = "normal";
+      session.close();
+    }
+  });
+
   test("excludes interactive tools by default without pinning an allowlist", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
@@ -1019,7 +1041,7 @@ describe("LettaAgentClient", () => {
     const session = client.createSession("agent-123");
     try {
       await asAdvanced(session).initialize();
-      await asAdvanced(session).sendAndWaitForResult("hello");
+      await session.sendAndWaitForResult("hello");
 
       const inputCommand = fakeControlSocket().sent.find(
         (command): command is Record<string, unknown> =>
@@ -1049,7 +1071,7 @@ describe("LettaAgentClient", () => {
     });
     try {
       await asAdvanced(session).initialize();
-      await asAdvanced(session).sendAndWaitForResult("hello");
+      await session.sendAndWaitForResult("hello");
 
       const inputCommand = fakeControlSocket().sent.find(
         (command): command is Record<string, unknown> =>
@@ -1269,7 +1291,7 @@ describe("LettaAgentClient", () => {
     });
     try {
       await asAdvanced(session).initialize();
-      const result = await asAdvanced(session).sendAndWaitForResult("read a file");
+      const result = await session.sendAndWaitForResult("read a file");
 
       expect(result).toMatchObject({
         type: "result",
@@ -1306,7 +1328,7 @@ describe("LettaAgentClient", () => {
     const session = client.createSession("agent-123");
     try {
       await asAdvanced(session).initialize();
-      const result = await asAdvanced(session).sendAndWaitForResult("use a tool");
+      const result = await session.sendAndWaitForResult("use a tool");
 
       expect(result).toMatchObject({
         type: "result",
@@ -1715,7 +1737,7 @@ describe("LettaAgentClient", () => {
     const session = client.createSession(agentId);
     try {
       await asAdvanced(session).initialize();
-      await asAdvanced(session).sendAndWaitForResult("hello");
+      await session.sendAndWaitForResult("hello");
 
       const inputCommand = fakeControlSocket().sent.find(
         (command): command is Record<string, unknown> =>
@@ -2175,7 +2197,7 @@ describe("LettaAgentClient", () => {
 
       // No default allowlist is sent, so the custom tool is never filtered
       // by the harness; interactive tools are excluded via the flag instead.
-      await asAdvanced(session).sendAndWaitForResult("hello");
+      await session.sendAndWaitForResult("hello");
       const inputCommand = fakeControlSocket().sent.find(
         (command): command is Record<string, unknown> =>
           typeof command === "object" && command !== null && "type" in command && command.type === "input",
@@ -2250,7 +2272,7 @@ describe("LettaAgentClient", () => {
         ],
       });
 
-      await asAdvanced(session).sendAndWaitForResult("hello");
+      await session.sendAndWaitForResult("hello");
       const inputCommand = fakeControlSocket().sent.find(
         (command): command is Record<string, unknown> =>
           typeof command === "object" && command !== null && "type" in command && command.type === "input",

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -662,7 +662,7 @@ describe("CloudEnvironmentSession", () => {
       const controlSocket = FakeCloudSocket.socket("control")!;
       expect(new URL(controlSocket.url).pathname).toBe("/v1/environments/conn-agent-1/status/ws");
 
-      const result = await asAdvanced(session).sendAndWaitForResult("hello");
+      const result = await session.sendAndWaitForResult("hello");
       expect(result).toMatchObject({ success: true, result: "hello from cloud" });
       expect(requests.filter((request) =>
         new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes/refresh"
@@ -870,7 +870,7 @@ describe("CloudEnvironmentSession", () => {
       // and retry without duplicating the message.
       let thrown: unknown;
       try {
-        await asAdvanced(session).sendAndWaitForResult("hello");
+        await session.sendAndWaitForResult("hello");
       } catch (error) {
         thrown = error;
       }
@@ -1408,7 +1408,7 @@ describe("CloudEnvironmentSession", () => {
       request_id: expect.any(String),
     }));
 
-    const result = await asAdvanced(session).sendAndWaitForResult("hello");
+    const result = await session.sendAndWaitForResult("hello");
     expect(result).toMatchObject({
       type: "result",
       success: true,
@@ -1459,7 +1459,7 @@ describe("CloudEnvironmentSession", () => {
       FakeCloudSocket.socket("stream")!.close();
       await Promise.resolve();
 
-      const result = await asAdvanced(session).sendAndWaitForResult("hello once");
+      const result = await session.sendAndWaitForResult("hello once");
       expect(result).toMatchObject({
         success: true,
         result: "hello from cloud",
@@ -1583,7 +1583,7 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("agent-1");
     try {
-      const result = await asAdvanced(session).sendAndWaitForResult("hello");
+      const result = await session.sendAndWaitForResult("hello");
       expect(result).toMatchObject({
         success: true,
         result: "hello once",
@@ -2151,7 +2151,7 @@ describe("CloudEnvironmentSession", () => {
       },
     });
 
-    const result = await asAdvanced(session).sendAndWaitForResult("run pwd");
+    const result = await session.sendAndWaitForResult("run pwd");
 
     expect(result).toMatchObject({ success: true, result: "approved" });
     expect(decisions).toEqual([
@@ -2210,7 +2210,7 @@ describe("CloudEnvironmentSession", () => {
       },
     });
 
-    const result = await asAdvanced(session).sendAndWaitForResult("run pwd");
+    const result = await session.sendAndWaitForResult("run pwd");
 
     expect(result).toMatchObject({ success: true, result: "approved" });
     expect(decisions).toEqual([{ toolName: "Bash", input: { command: "pwd" } }]);
@@ -2442,7 +2442,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    const result = await asAdvanced(session).sendAndWaitForResult("trigger failure");
+    const result = await session.sendAndWaitForResult("trigger failure");
 
     expect(result).toMatchObject({
       type: "result",
@@ -2473,7 +2473,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    const result = await asAdvanced(session).sendAndWaitForResult("trigger delayed failure");
+    const result = await session.sendAndWaitForResult("trigger delayed failure");
 
     expect(result).toMatchObject({
       type: "result",

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -6,6 +6,7 @@ type AssertFalse<T extends false> = T;
 type HasKey<K extends PropertyKey> = K extends keyof LettaCodeSession ? true : false;
 
 type _HasSend = AssertTrue<HasKey<"send">>;
+type _HasSendAndWaitForResult = AssertTrue<HasKey<"sendAndWaitForResult">>;
 type _HasStream = AssertTrue<HasKey<"stream">>;
 type _HasAbort = AssertTrue<HasKey<"abort">>;
 type _HasSendCommand = AssertTrue<HasKey<"sendCommand">>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -761,6 +761,16 @@ export interface LettaCodeSession extends AsyncDisposable {
    * optimistic reconciliation; the SDK generates one when omitted.
    */
   send(message: SendMessage, options?: SendOptions): Promise<void>;
+  /**
+   * Send one user message and resolve with its terminal result.
+   *
+   * This method consumes the session stream internally. Use `send()` and
+   * `stream()` when the caller needs intermediate events or wants the runtime
+   * to queue another message behind an active turn.
+   *
+   * Rejects if this session already has a turn in flight.
+   */
+  sendAndWaitForResult(message: SendMessage): Promise<SDKResultMessage>;
   stream(): AsyncGenerator<SDKMessage>;
   abort(): Promise<void>;
   sendCommand(command: SDKProtocolCommand): Promise<void>;


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- expose the existing `sendAndWaitForResult()` helper on `LettaCodeSession`
- let created or resumed sessions return the terminal `SDKResultMessage` without processing intermediate events
- remove internal type casts and pin the public method plus its active-turn rejection

## Behavior
The method consumes the runtime stream internally. Callers that need reasoning, tool, queue, retry, or error events continue to use `send()` with `stream()`.

`client.prompt()` keeps its current behavior. It creates a new conversation on the agent, waits for the result, and closes the short-lived SDK session. The conversation remains persisted.

## Test plan
- [x] `bun run check`
- [x] `bun test` (256 passed, 11 live tests skipped)
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)