### PR TITLE
fix(examples): preserve the harness for role instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ const client = new LettaAgentClient({ backend: "cloud" });
 
 // Create the agent once...
 const agentId = await client.createAgent({
-  systemPrompt: "You are Nora, a research analyst who tracks our competitors.",
-  memfs: true,
+  persona: "You are Nora, a research analyst who tracks our competitors.",
 });
 
 // ...then resume it, from anywhere, for as long as it lives.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
 const client = new LettaAgentClient({ backend: "cloud" });
 
-// Create the agent once. The preset keeps the default harness and MemFS guidance.
-const agentId = await client.createAgent({ personality: "memo" });
+// Create the agent once...
+const agentId = await client.createAgent({
+  systemPrompt: "You are Nora, a research analyst who tracks our competitors.",
+  memfs: true,
+});
 
 // ...then resume it, from anywhere, for as long as it lives.
 await using session = client.resumeSession(agentId);

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
 const client = new LettaAgentClient({ backend: "cloud" });
 
-// Create the agent once...
-const agentId = await client.createAgent({
-  persona: "You are Nora, a research analyst who tracks our competitors.",
-});
+// Create the agent once. The preset keeps the default harness and MemFS guidance.
+const agentId = await client.createAgent({ personality: "memo" });
 
 // ...then resume it, from anywhere, for as long as it lives.
 await using session = client.resumeSession(agentId);

--- a/examples/bug-fixer/fixer.ts
+++ b/examples/bug-fixer/fixer.ts
@@ -94,7 +94,7 @@ export async function getOrCreateAgent(state: BugFixerState): Promise<LettaCodeS
   console.log(`${COLORS.system}Creating new bug fixer agent...${COLORS.reset}`);
   const session = await createAgentSession({
     model: DEFAULT_CONFIG.model,
-    systemPrompt: SYSTEM_PROMPT,
+    instructions: SYSTEM_PROMPT,
     allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/create-agent-session.ts
+++ b/examples/create-agent-session.ts
@@ -29,11 +29,30 @@ export function createExampleClient(
 
 type ExampleCreateOptions = Omit<
   CreateAgentOptions,
-  "disallowedTools" | "systemInfoReminder"
+  | "disallowedTools"
+  | "human"
+  | "memory"
+  | "persona"
+  | "systemInfoReminder"
 >;
 
-// Keep internal controls that would distract from the session APIs out of the
-// examples while passing creation memory through unchanged.
+// Keep the examples on the current personality and MemFS model. The omitted
+// fields are legacy creation options or internal controls that would distract
+// from the session APIs demonstrated here.
+
+const MEMFS_GUIDANCE = `## Persistent memory
+This agent has a git-backed memory filesystem. Use memory files for durable
+knowledge instead of memory blocks. Keep stable identity and behavior in
+system/ files. Keep project notes, learned preferences, and history in focused
+Markdown files under reference/. Never store secrets in memory.`;
+
+function withMemfsGuidance(
+  systemPrompt: CreateAgentOptions["systemPrompt"],
+): CreateAgentOptions["systemPrompt"] {
+  return typeof systemPrompt === "string"
+    ? `${systemPrompt}\n\n${MEMFS_GUIDANCE}`
+    : systemPrompt;
+}
 
 function sessionOptionsFrom(
   options: ExampleCreateOptions,
@@ -59,11 +78,8 @@ export async function createExampleAgent(
     personality: options.personality,
     model: options.model,
     embedding: options.embedding,
-    systemPrompt: options.systemPrompt,
-    memory: options.memory,
-    persona: options.persona,
-    human: options.human,
-    memfs: options.memfs,
+    systemPrompt: withMemfsGuidance(options.systemPrompt),
+    memfs: options.memfs ?? true,
     name: options.name,
     description: options.description,
     hidden: options.hidden,

--- a/examples/create-agent-session.ts
+++ b/examples/create-agent-session.ts
@@ -34,10 +34,14 @@ type ExampleCreateOptions = Omit<
   | "memory"
   | "persona"
   | "systemInfoReminder"
->;
+  | "systemPrompt"
+> & {
+  /** Instructions appended to the maintained default harness prompt. */
+  instructions?: string;
+};
 
 // Keep legacy creation-memory fields and internal controls out of the examples.
-// A custom systemPrompt is a complete replacement, so pass it through unchanged.
+// Role instructions append to the maintained harness instead of replacing it.
 
 function sessionOptionsFrom(
   options: ExampleCreateOptions,
@@ -63,7 +67,9 @@ export async function createExampleAgent(
     personality: options.personality,
     model: options.model,
     embedding: options.embedding,
-    systemPrompt: options.systemPrompt,
+    systemPrompt: options.instructions === undefined
+      ? undefined
+      : { type: "preset", preset: "default", append: options.instructions },
     memfs: options.memfs,
     name: options.name,
     description: options.description,

--- a/examples/create-agent-session.ts
+++ b/examples/create-agent-session.ts
@@ -36,23 +36,8 @@ type ExampleCreateOptions = Omit<
   | "systemInfoReminder"
 >;
 
-// Keep the examples on the current personality and MemFS model. The omitted
-// fields are legacy creation options or internal controls that would distract
-// from the session APIs demonstrated here.
-
-const MEMFS_GUIDANCE = `## Persistent memory
-This agent has a git-backed memory filesystem. Use memory files for durable
-knowledge instead of memory blocks. Keep stable identity and behavior in
-system/ files. Keep project notes, learned preferences, and history in focused
-Markdown files under reference/. Never store secrets in memory.`;
-
-function withMemfsGuidance(
-  systemPrompt: CreateAgentOptions["systemPrompt"],
-): CreateAgentOptions["systemPrompt"] {
-  return typeof systemPrompt === "string"
-    ? `${systemPrompt}\n\n${MEMFS_GUIDANCE}`
-    : systemPrompt;
-}
+// Keep legacy creation-memory fields and internal controls out of the examples.
+// A custom systemPrompt is a complete replacement, so pass it through unchanged.
 
 function sessionOptionsFrom(
   options: ExampleCreateOptions,
@@ -78,8 +63,8 @@ export async function createExampleAgent(
     personality: options.personality,
     model: options.model,
     embedding: options.embedding,
-    systemPrompt: withMemfsGuidance(options.systemPrompt),
-    memfs: options.memfs ?? true,
+    systemPrompt: options.systemPrompt,
+    memfs: options.memfs,
     name: options.name,
     description: options.description,
     hidden: options.hidden,

--- a/examples/create-agent-session.ts
+++ b/examples/create-agent-session.ts
@@ -29,30 +29,11 @@ export function createExampleClient(
 
 type ExampleCreateOptions = Omit<
   CreateAgentOptions,
-  | "disallowedTools"
-  | "human"
-  | "memory"
-  | "persona"
-  | "systemInfoReminder"
+  "disallowedTools" | "systemInfoReminder"
 >;
 
-// Keep the examples on the current personality and MemFS model. The omitted
-// fields are legacy creation options or internal controls that would distract
-// from the session APIs demonstrated here.
-
-const MEMFS_GUIDANCE = `## Persistent memory
-This agent has a git-backed memory filesystem. Use memory files for durable
-knowledge instead of memory blocks. Keep stable identity and behavior in
-system/ files. Keep project notes, learned preferences, and history in focused
-Markdown files under reference/. Never store secrets in memory.`;
-
-function withMemfsGuidance(
-  systemPrompt: CreateAgentOptions["systemPrompt"],
-): CreateAgentOptions["systemPrompt"] {
-  return typeof systemPrompt === "string"
-    ? `${systemPrompt}\n\n${MEMFS_GUIDANCE}`
-    : systemPrompt;
-}
+// Keep internal controls that would distract from the session APIs out of the
+// examples while passing creation memory through unchanged.
 
 function sessionOptionsFrom(
   options: ExampleCreateOptions,
@@ -78,8 +59,11 @@ export async function createExampleAgent(
     personality: options.personality,
     model: options.model,
     embedding: options.embedding,
-    systemPrompt: withMemfsGuidance(options.systemPrompt),
-    memfs: options.memfs ?? true,
+    systemPrompt: options.systemPrompt,
+    memory: options.memory,
+    persona: options.persona,
+    human: options.human,
+    memfs: options.memfs,
     name: options.name,
     description: options.description,
     hidden: options.hidden,

--- a/examples/custom-tools/main.ts
+++ b/examples/custom-tools/main.ts
@@ -116,7 +116,11 @@ async function main() {
 
   const agentId = await client.createAgent({
     model: "letta/auto",
-    systemPrompt: "You are a helpful assistant with access to custom tools.",
+    systemPrompt: {
+      type: "preset",
+      preset: "default",
+      append: "You are a helpful assistant with access to custom tools.",
+    },
     memfs: false,
   });
   console.log("Created agent:", agentId);

--- a/examples/dungeon-master/dm.ts
+++ b/examples/dungeon-master/dm.ts
@@ -105,7 +105,7 @@ export async function createDM(state: GameState): Promise<LettaCodeSession> {
   // Create new DM
   const session = await createAgentSession({
     model: DEFAULT_CONFIG.model,
-    systemPrompt: `You are a Dungeon Master - a creative storyteller and game designer who runs tabletop RPG campaigns.
+    instructions: `You are a Dungeon Master - a creative storyteller and game designer who runs tabletop RPG campaigns.
 
 ## Your Role
 - Design and run engaging tabletop RPG experiences

--- a/examples/economics-seminar/faculty.ts
+++ b/examples/economics-seminar/faculty.ts
@@ -70,7 +70,7 @@ export async function createFacultyMember(
   
   return createAgentSession({
     model: config.model,
-    systemPrompt: getFacultySystemPrompt(faculty),
+    instructions: getFacultySystemPrompt(faculty),
     allowedTools: ['Read', 'Write'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/economics-seminar/presenter.ts
+++ b/examples/economics-seminar/presenter.ts
@@ -64,7 +64,7 @@ export async function createPresenter(
   
   return createAgentSession({
     model: config.model,
-    systemPrompt: PRESENTER_SYSTEM_PROMPT,
+    instructions: PRESENTER_SYSTEM_PROMPT,
     allowedTools: ['Read', 'Write'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/file-organizer/organizer.ts
+++ b/examples/file-organizer/organizer.ts
@@ -98,7 +98,7 @@ export async function getOrCreateAgent(state: FileOrganizerState): Promise<Letta
   console.log(`${COLORS.system}Creating new file organizer agent...${COLORS.reset}`);
   const session = await createAgentSession({
     model: DEFAULT_CONFIG.model,
-    systemPrompt: SYSTEM_PROMPT,
+    instructions: SYSTEM_PROMPT,
     allowedTools: ['Bash', 'Read', 'Glob'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/focus-group/agents.ts
+++ b/examples/focus-group/agents.ts
@@ -41,7 +41,7 @@ Keep durable messaging lessons in reference/candidate-lessons.md.`;
 export async function createCandidateAgent(): Promise<LettaCodeSession> {
   return createAgentSession({
     model: CONFIG.model,
-    systemPrompt: CANDIDATE_PROMPT,
+    instructions: CANDIDATE_PROMPT,
     permissionMode: 'unrestricted',
   }, client);
 }
@@ -89,7 +89,7 @@ Keep durable changes to your preferences in reference/voter-profile.md.`;
 export async function createVoterAgent(persona: VoterPersona): Promise<LettaCodeSession> {
   return createAgentSession({
     model: CONFIG.model,
-    systemPrompt: buildVoterPrompt(persona),
+    instructions: buildVoterPrompt(persona),
     permissionMode: 'unrestricted',
   }, client);
 }
@@ -125,7 +125,7 @@ Keep durable response patterns in reference/focus-group-patterns.md.`;
 export async function createAnalystAgent(): Promise<LettaCodeSession> {
   return createAgentSession({
     model: CONFIG.model,
-    systemPrompt: ANALYST_PROMPT,
+    instructions: ANALYST_PROMPT,
     permissionMode: 'unrestricted',
   }, client);
 }

--- a/examples/release-notes/generator.ts
+++ b/examples/release-notes/generator.ts
@@ -110,7 +110,7 @@ export async function getOrCreateAgent(state: ReleaseNotesState): Promise<LettaC
   console.log(`${COLORS.system}Creating new release notes agent...${COLORS.reset}`);
   const session = await createAgentSession({
     model: DEFAULT_CONFIG.model,
-    systemPrompt: SYSTEM_PROMPT,
+    instructions: SYSTEM_PROMPT,
     allowedTools: ['Bash', 'Read', 'Write', 'Glob'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/research-team/agents/analyst.ts
+++ b/examples/research-team/agents/analyst.ts
@@ -65,7 +65,7 @@ export async function createAnalyst(
   
   return createAgentSession({
     model: 'haiku',
-    systemPrompt: ANALYST_SYSTEM_PROMPT,
+    instructions: ANALYST_SYSTEM_PROMPT,
     allowedTools: ['Glob', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/research-team/agents/researcher.ts
+++ b/examples/research-team/agents/researcher.ts
@@ -79,7 +79,7 @@ export async function createResearcher(
   
   return createAgentSession({
     model: 'haiku',
-    systemPrompt: RESEARCHER_SYSTEM_PROMPT,
+    instructions: RESEARCHER_SYSTEM_PROMPT,
     allowedTools: ['Glob', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/research-team/agents/writer.ts
+++ b/examples/research-team/agents/writer.ts
@@ -83,7 +83,7 @@ export async function createWriter(
   
   return createAgentSession({
     model: 'haiku',
-    systemPrompt: WRITER_SYSTEM_PROMPT,
+    instructions: WRITER_SYSTEM_PROMPT,
     allowedTools: ['Glob', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   }, client);

--- a/examples/sdk-tour.ts
+++ b/examples/sdk-tour.ts
@@ -536,9 +536,8 @@ async function testSystemPrompt() {
 async function testMemfs() {
   console.log('=== Memory Filesystem ===\n');
 
-  const agentId = await client.createAgent({
-    persona: 'You are a stateful agent with durable memory.',
-  });
+  // Omitting systemPrompt keeps the default harness and its MemFS guidance.
+  const agentId = await client.createAgent();
   await using session = client.resumeSession(agentId, {
     permissionMode: 'unrestricted',
   });

--- a/examples/sdk-tour.ts
+++ b/examples/sdk-tour.ts
@@ -537,9 +537,7 @@ async function testMemfs() {
   console.log('=== Memory Filesystem ===\n');
 
   const agentId = await client.createAgent({
-    memfs: true,
-    systemPrompt: `Use focused Markdown files under reference/ for durable
-knowledge. Never store secrets in memory.`,
+    persona: 'You are a stateful agent with durable memory.',
   });
   await using session = client.resumeSession(agentId, {
     permissionMode: 'unrestricted',

--- a/examples/sdk-tour.ts
+++ b/examples/sdk-tour.ts
@@ -10,7 +10,10 @@
  * Run with: bun examples/sdk-tour.ts [example]
  */
 
-import { LettaAgentClient } from '../src/index.js';
+import {
+  LettaAgentClient,
+  type CreateAgentOptions,
+} from '../src/index.js';
 
 const client = new LettaAgentClient({ backend: 'local' });
 
@@ -218,7 +221,7 @@ async function testOptions() {
 
   // Set a system prompt preset when you create the agent.
   console.log('Testing systemPrompt preset...');
-  const systemPromptAgentId = await client.createAgent({ systemPrompt: 'letta-claude' });
+  const systemPromptAgentId = await client.createAgent({ systemPrompt: 'default' });
   const sysPromptSession = client.createSession(systemPromptAgentId, {
     permissionMode: 'unrestricted',
   });
@@ -475,7 +478,10 @@ async function testPermissionCallback() {
 async function testSystemPrompt() {
   console.log('=== System Prompts ===\n');
 
-  async function runWithSystemPrompt(msg: string, systemPrompt: any): Promise<string> {
+  async function runWithSystemPrompt(
+    msg: string,
+    systemPrompt: CreateAgentOptions['systemPrompt'],
+  ): Promise<string> {
     const agentId = await client.createAgent({ systemPrompt });
     const session = client.resumeSession(agentId, { permissionMode: 'unrestricted' });
     await session.send(msg);
@@ -491,16 +497,16 @@ async function testSystemPrompt() {
   console.log('Testing preset system prompt...');
   const presetResult = await runWithSystemPrompt(
     'What kind of agent are you? One sentence.',
-    { type: 'preset', preset: 'letta-claude' }
+    { type: 'preset', preset: 'default' }
   );
-  console.log(`  preset (letta-claude): ${presetResult ? 'PASS' : 'FAIL'}`);
+  console.log(`  preset (default): ${presetResult ? 'PASS' : 'FAIL'}`);
   console.log(`    Response: ${presetResult.slice(0, 80)}...`);
 
   // Test 2: Preset with append
   console.log('Testing preset with append...');
   const appendResult = await runWithSystemPrompt(
     'Say hello',
-    { type: 'preset', preset: 'letta-claude', append: 'Always end your responses with "🎉"' }
+    { type: 'preset', preset: 'default', append: 'Always end your responses with "🎉"' }
   );
   const hasEmoji = appendResult.includes('🎉');
   console.log(`  preset with append: ${hasEmoji ? 'PASS' : 'CHECK'}`);
@@ -518,13 +524,13 @@ async function testSystemPrompt() {
   console.log(`  custom string: ${customResult ? 'PASS' : 'FAIL'}`);
   console.log(`    Response: ${customResult.slice(0, 80)}...`);
 
-  // Test 4: Basic preset (claude - no skills/memory)
-  console.log('Testing basic preset (claude)...');
+  // Test 4: Source-faithful preset (no Letta skills or memory guidance)
+  console.log('Testing source-faithful Claude preset...');
   const basicResult = await runWithSystemPrompt(
     'Hello, just say hi back',
-    { type: 'preset', preset: 'claude' }
+    { type: 'preset', preset: 'source-claude' }
   );
-  console.log(`  basic preset (claude): ${basicResult ? 'PASS' : 'FAIL'}`);
+  console.log(`  source-claude preset: ${basicResult ? 'PASS' : 'FAIL'}`);
 
   console.log();
 }

--- a/examples/web-chat/server.ts
+++ b/examples/web-chat/server.ts
@@ -121,7 +121,7 @@ async function getSession(): Promise<LettaCodeSession> {
     console.log('Creating new agent...');
     const agentId = await createExampleAgent({
       model: 'haiku',
-      systemPrompt: `You are a helpful assistant accessible through a web interface.
+      instructions: `You are a helpful assistant accessible through a web interface.
 
 Be concise but friendly. You can help with:
 - Answering questions

--- a/src/agent-creation.ts
+++ b/src/agent-creation.ts
@@ -2,19 +2,49 @@ import {
   buildCreateAgentRequest,
   type CreateAgentMemoryBlock,
   type CreateAgentRequest,
+  buildSystemPrompt,
 } from "@letta-ai/letta-code/agent-presets";
-import type { CreateAgentOptions } from "./types.js";
+import type {
+  CreateAgentOptions,
+  SystemPromptConfig,
+  SystemPromptPreset,
+} from "./types.js";
 
-function isPresetSystemPrompt(value: string): boolean {
-  return [
-    "default",
-    "letta-claude",
-    "letta-codex",
-    "letta-gemini",
-    "claude",
-    "codex",
-    "gemini",
-  ].includes(value);
+const SYSTEM_PROMPT_PRESET_IDS = {
+  default: "default",
+  letta: "letta",
+  "source-claude": "source-claude",
+  "source-codex": "source-codex",
+  "source-gemini": "source-gemini",
+  "letta-claude": "letta",
+  "letta-codex": "letta",
+  "letta-gemini": "letta",
+  claude: "source-claude",
+  codex: "source-codex",
+  gemini: "source-gemini",
+} as const satisfies Record<SystemPromptPreset, string>;
+
+function isPresetSystemPrompt(value: string): value is SystemPromptPreset {
+  return Object.hasOwn(SYSTEM_PROMPT_PRESET_IDS, value);
+}
+
+function resolveSystemPrompt(
+  config: SystemPromptConfig,
+  memoryMode: "memfs" | "standard",
+): string {
+  if (typeof config === "string") {
+    return isPresetSystemPrompt(config)
+      ? buildSystemPrompt(SYSTEM_PROMPT_PRESET_IDS[config], memoryMode)
+      : config;
+  }
+
+  const base = buildSystemPrompt(
+    SYSTEM_PROMPT_PRESET_IDS[config.preset],
+    memoryMode,
+  );
+  return config.append === undefined || config.append.length === 0
+    ? base
+    : `${base}\n\n${config.append}`;
 }
 
 function assertCreateAgentOptionsSupported(options: CreateAgentOptions): void {
@@ -49,18 +79,12 @@ export async function createAgentBody(
 ): Promise<CreateAgentRequest> {
   assertCreateAgentOptionsSupported(options);
 
-  let system: string | undefined;
-  if (options.systemPrompt !== undefined) {
-    if (
-      typeof options.systemPrompt !== "string" ||
-      isPresetSystemPrompt(options.systemPrompt)
-    ) {
-      throw new Error(
-        "createAgent() does not yet support system prompt presets for this backend.",
+  const system = options.systemPrompt === undefined
+    ? undefined
+    : resolveSystemPrompt(
+        options.systemPrompt,
+        options.memfs === false ? "standard" : "memfs",
       );
-    }
-    system = options.systemPrompt;
-  }
 
   const memoryBlocks: CreateAgentMemoryBlock[] = [];
   const blockIds: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,12 +218,9 @@ export {
  *
  * @example
  * ```typescript
- * // Create a stateful agent with initial memory and the default harness prompt.
+ * // Create a stateful agent with the default harness and MemFS guidance.
  * const agentId = await createAgent({
- *   memory: [
- *     { label: 'persona', value: 'You are a careful coding assistant.' },
- *     { label: 'project', value: 'Use Bun for the docs project.' },
- *   ],
+ *   personality: 'memo',
  *   model: 'claude-sonnet-4',
  *   tags: ['project:docs']
  * });

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,11 +218,12 @@ export {
  *
  * @example
  * ```typescript
- * // Create an agent with a git-backed memory filesystem.
+ * // Create a stateful agent with initial memory and the default harness prompt.
  * const agentId = await createAgent({
- *   memfs: true,
- *   systemPrompt: `You are a helpful coding assistant. Keep durable project
- *     notes in focused Markdown files under reference/.`,
+ *   memory: [
+ *     { label: 'persona', value: 'You are a careful coding assistant.' },
+ *     { label: 'project', value: 'Use Bun for the docs project.' },
+ *   ],
  *   model: 'claude-sonnet-4',
  *   tags: ['project:docs']
  * });

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,11 +218,13 @@ export {
  *
  * @example
  * ```typescript
- * // Create an agent with a git-backed memory filesystem.
+ * // Add role instructions without replacing the maintained harness prompt.
  * const agentId = await createAgent({
- *   memfs: true,
- *   systemPrompt: `You are a helpful coding assistant. Keep durable project
- *     notes in focused Markdown files under reference/.`,
+ *   systemPrompt: {
+ *     type: 'preset',
+ *     preset: 'default',
+ *     append: 'You are a helpful coding assistant for the docs project.',
+ *   },
  *   model: 'claude-sonnet-4',
  *   tags: ['project:docs']
  * });

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,9 +218,11 @@ export {
  *
  * @example
  * ```typescript
- * // Create a stateful agent with the default harness and MemFS guidance.
+ * // Create an agent with a git-backed memory filesystem.
  * const agentId = await createAgent({
- *   personality: 'memo',
+ *   memfs: true,
+ *   systemPrompt: `You are a helpful coding assistant. Keep durable project
+ *     notes in focused Markdown files under reference/.`,
  *   model: 'claude-sonnet-4',
  *   tags: ['project:docs']
  * });

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -57,24 +57,36 @@ describe("createAgentBody", () => {
     );
   });
 
-  test("translates convenience memory inputs before canonical creation", async () => {
+  test("keeps the default MemFS harness while translating creation memory", async () => {
     const body = await createAgentBody({
-      personality: "memo",
       memory: [
-        { label: "persona", value: "Memory persona" },
+        { label: "project", value: "SDK initialization correction" },
+        { label: "persona", value: "You are Nora, a research analyst." },
+        { label: "human", value: "The human tracks competitors." },
         { blockId: "block-shared" },
       ],
-      persona: "Convenience persona",
-      human: "Convenience human",
     });
 
-    expect(body.memory_blocks).toEqual(
-      expect.arrayContaining([
-        { label: "persona", value: "Convenience persona" },
-        { label: "human", value: "Convenience human" },
-      ]),
-    );
+    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
+    expect(body.memory_blocks).toEqual([
+      { label: "project", value: "SDK initialization correction" },
+      { label: "persona", value: "You are Nora, a research analyst." },
+      { label: "human", value: "The human tracks competitors." },
+    ]);
     expect(body.block_ids).toEqual(["block-shared"]);
+  });
+
+  test("keeps the default MemFS harness with persona and human shorthand", async () => {
+    const body = await createAgentBody({
+      persona: "You are Nora, a research analyst.",
+      human: "The human tracks competitors.",
+    });
+
+    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
+    expect(body.memory_blocks).toEqual([
+      { label: "persona", value: "You are Nora, a research analyst." },
+      { label: "human", value: "The human tracks competitors." },
+    ]);
   });
 
   test("keeps MemFS mode and exact base tools in the canonical request", async () => {

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -94,4 +94,28 @@ describe("createAgentBody", () => {
       })).system,
     ).toBe("You are a focused research assistant.");
   });
+
+  test("resolves current and legacy managed prompt presets", async () => {
+    expect((await createAgentBody({ systemPrompt: "default" })).system).toBe(
+      buildSystemPrompt("default", "memfs"),
+    );
+    expect((await createAgentBody({ systemPrompt: "letta-codex" })).system).toBe(
+      buildSystemPrompt("letta", "memfs"),
+    );
+    expect(
+      (await createAgentBody({ memfs: false, systemPrompt: "source-codex" }))
+        .system,
+    ).toBe(buildSystemPrompt("source-codex", "standard"));
+  });
+
+  test("appends instructions to the managed prompt", async () => {
+    const append = "Write concise release notes.";
+    const body = await createAgentBody({
+      systemPrompt: { type: "preset", preset: "default", append },
+    });
+
+    expect(body.system).toBe(
+      `${buildSystemPrompt("default", "memfs")}\n\n${append}`,
+    );
+  });
 });

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -57,36 +57,24 @@ describe("createAgentBody", () => {
     );
   });
 
-  test("keeps the default MemFS harness while translating creation memory", async () => {
+  test("translates convenience memory inputs before canonical creation", async () => {
     const body = await createAgentBody({
+      personality: "memo",
       memory: [
-        { label: "project", value: "SDK initialization correction" },
-        { label: "persona", value: "You are Nora, a research analyst." },
-        { label: "human", value: "The human tracks competitors." },
+        { label: "persona", value: "Memory persona" },
         { blockId: "block-shared" },
       ],
+      persona: "Convenience persona",
+      human: "Convenience human",
     });
 
-    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
-    expect(body.memory_blocks).toEqual([
-      { label: "project", value: "SDK initialization correction" },
-      { label: "persona", value: "You are Nora, a research analyst." },
-      { label: "human", value: "The human tracks competitors." },
-    ]);
+    expect(body.memory_blocks).toEqual(
+      expect.arrayContaining([
+        { label: "persona", value: "Convenience persona" },
+        { label: "human", value: "Convenience human" },
+      ]),
+    );
     expect(body.block_ids).toEqual(["block-shared"]);
-  });
-
-  test("keeps the default MemFS harness with persona and human shorthand", async () => {
-    const body = await createAgentBody({
-      persona: "You are Nora, a research analyst.",
-      human: "The human tracks competitors.",
-    });
-
-    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
-    expect(body.memory_blocks).toEqual([
-      { label: "persona", value: "You are Nora, a research analyst." },
-      { label: "human", value: "The human tracks competitors." },
-    ]);
   });
 
   test("keeps MemFS mode and exact base tools in the canonical request", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
 import {
   CloudManagedSandboxExpiredError,
   LettaAgentClient,
@@ -2102,9 +2103,10 @@ describe("CloudEnvironmentSession", () => {
     await expect(client.createAgent({
       model: "anthropic/claude-sonnet-4",
       systemPrompt: "default",
-    })).rejects.toThrow(
-      "createAgent() does not yet support system prompt presets for this backend",
-    );
+    })).resolves.toBe("agent-created");
+    expect(requests[1]?.body).toMatchObject({
+      system: buildSystemPrompt("default", "memfs"),
+    });
   });
 
   test("uses the Letta Code default model for Cloud createAgent", async () => {

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -135,6 +135,22 @@ describe("validation", () => {
     }
   });
 
+  test("accepts current managed prompt presets and append configuration", () => {
+    for (const preset of [
+      "default",
+      "letta",
+      "source-claude",
+      "source-codex",
+      "source-gemini",
+    ] as const) {
+      expect(() =>
+        validateCreateAgentOptions({
+          systemPrompt: { type: "preset", preset, append: "Role instructions" },
+        }),
+      ).not.toThrow();
+    }
+  });
+
   test("rejects invalid agent skill source", () => {
     expect(() =>
       validateCreateAgentOptions({

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,13 +168,23 @@ export interface EffectiveDreamingSettings {
  * Available system prompt presets.
  */
 export type SystemPromptPreset =
-  | "default" // Alias for letta-claude
-  | "letta-claude" // Full Letta Code prompt (Claude-optimized)
-  | "letta-codex" // Full Letta Code prompt (Codex-optimized)
-  | "letta-gemini" // Full Letta Code prompt (Gemini-optimized)
-  | "claude" // Basic Claude (no skills/memory instructions)
-  | "codex" // Basic Codex
-  | "gemini"; // Basic Gemini
+  | "default"
+  | "letta"
+  | "source-claude"
+  | "source-codex"
+  | "source-gemini"
+  /** @deprecated Use `letta`. */
+  | "letta-claude"
+  /** @deprecated Use `letta`. */
+  | "letta-codex"
+  /** @deprecated Use `letta`. */
+  | "letta-gemini"
+  /** @deprecated Use `source-claude`. */
+  | "claude"
+  /** @deprecated Use `source-codex`. */
+  | "codex"
+  /** @deprecated Use `source-gemini`. */
+  | "gemini";
 
 /**
  * System prompt preset configuration.

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,13 +201,17 @@ export interface BlockReference {
   blockId: string;
 }
 
-/** Creation memory: a preset, inline value, or existing block reference. */
+/**
+ * Memory item - can be a preset name, custom block, or block reference.
+ */
 export type MemoryItem =
   | string // Preset name: "project", "persona", "human"
-  | CreateBlock // Inline memory: { label, value, description? }
+  | CreateBlock // Custom block: { label, value, description? }
   | BlockReference; // Shared block reference: { blockId }
 
-/** Default creation-memory preset names. */
+/**
+ * Default memory block preset names.
+ */
 export type MemoryPreset = "persona" | "human" | "skills" | "loaded_skills";
 
 // ═══════════════════════════════════════════════════════════════
@@ -907,37 +911,23 @@ export interface CreateAgentOptions {
    * - string: Use as the complete system prompt
    * - SystemPromptPreset: Use a preset
    * - { type: 'preset', preset, append? }: Use a preset with optional appended text
-   *
-   * Most stateful agents should keep the default harness prompt and initialize
-   * identity and user context through `memory`, `persona`, or `human` instead.
    */
   systemPrompt?: string | SystemPromptPreset | SystemPromptPresetConfigSDK;
 
   /**
-   * Memory supplied when the agent is created. Each item can be:
-   * - string: Preset name ("persona", "human", "skills", "loaded_skills")
-   * - CreateBlock: Inline memory (e.g., { label: "project", value: "..." })
-   * - { blockId: string }: Reference to an existing shared block
-   *
-   * For hosted Cloud agents with MemFS enabled, inline memory is sent through
-   * the legacy-named `memory_blocks` request field and seeds initial MemFS
-   * files without creating block rows. Ordinary labels map to
-   * `system/<label>.md`. Other backends can retain block-backed memory. Use
-   * this array, rather than the `persona` and `human` shorthands, when you need
-   * several inline memory entries.
+   * Legacy memory block configuration. New agents should use the git-backed
+   * memory filesystem instead. Each item can be:
+   * - string: Preset block name ("persona", "human", "skills", "loaded_skills")
+   * - CreateBlock: Custom block definition (e.g., { label: "project", value: "..." })
+   * - { blockId: string }: Reference to existing shared block
+   * @deprecated Prefer `memfs` and let the agent maintain memory files.
    */
   memory?: MemoryItem[];
 
-  /**
-   * Persona supplied as creation memory. Hosted Cloud MemFS seeds it as
-   * `system/persona.md`; other backends can retain block-backed memory.
-   */
+  /** @deprecated Prefer a personality preset or a system memory file. */
   persona?: string;
 
-  /**
-   * Human context supplied as creation memory. Hosted Cloud MemFS seeds it as
-   * `system/human.md`; other backends can retain block-backed memory.
-   */
+  /** @deprecated Prefer a focused memory file for user preferences. */
   human?: string;
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,17 +201,13 @@ export interface BlockReference {
   blockId: string;
 }
 
-/**
- * Memory item - can be a preset name, custom block, or block reference.
- */
+/** Creation memory: a preset, inline value, or existing block reference. */
 export type MemoryItem =
   | string // Preset name: "project", "persona", "human"
-  | CreateBlock // Custom block: { label, value, description? }
+  | CreateBlock // Inline memory: { label, value, description? }
   | BlockReference; // Shared block reference: { blockId }
 
-/**
- * Default memory block preset names.
- */
+/** Default creation-memory preset names. */
 export type MemoryPreset = "persona" | "human" | "skills" | "loaded_skills";
 
 // ═══════════════════════════════════════════════════════════════
@@ -911,23 +907,37 @@ export interface CreateAgentOptions {
    * - string: Use as the complete system prompt
    * - SystemPromptPreset: Use a preset
    * - { type: 'preset', preset, append? }: Use a preset with optional appended text
+   *
+   * Most stateful agents should keep the default harness prompt and initialize
+   * identity and user context through `memory`, `persona`, or `human` instead.
    */
   systemPrompt?: string | SystemPromptPreset | SystemPromptPresetConfigSDK;
 
   /**
-   * Legacy memory block configuration. New agents should use the git-backed
-   * memory filesystem instead. Each item can be:
-   * - string: Preset block name ("persona", "human", "skills", "loaded_skills")
-   * - CreateBlock: Custom block definition (e.g., { label: "project", value: "..." })
-   * - { blockId: string }: Reference to existing shared block
-   * @deprecated Prefer `memfs` and let the agent maintain memory files.
+   * Memory supplied when the agent is created. Each item can be:
+   * - string: Preset name ("persona", "human", "skills", "loaded_skills")
+   * - CreateBlock: Inline memory (e.g., { label: "project", value: "..." })
+   * - { blockId: string }: Reference to an existing shared block
+   *
+   * For hosted Cloud agents with MemFS enabled, inline memory is sent through
+   * the legacy-named `memory_blocks` request field and seeds initial MemFS
+   * files without creating block rows. Ordinary labels map to
+   * `system/<label>.md`. Other backends can retain block-backed memory. Use
+   * this array, rather than the `persona` and `human` shorthands, when you need
+   * several inline memory entries.
    */
   memory?: MemoryItem[];
 
-  /** @deprecated Prefer a personality preset or a system memory file. */
+  /**
+   * Persona supplied as creation memory. Hosted Cloud MemFS seeds it as
+   * `system/persona.md`; other backends can retain block-backed memory.
+   */
   persona?: string;
 
-  /** @deprecated Prefer a focused memory file for user preferences. */
+  /**
+   * Human context supplied as creation memory. Hosted Cloud MemFS seeds it as
+   * `system/human.md`; other backends can retain block-backed memory.
+   */
   human?: string;
 
   /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -88,6 +88,10 @@ function validateRemovedSessionOptions(options: CreateSessionOptions): void {
 function validateSystemPromptPreset(preset: string): void {
   const validPresets = [
     "default",
+    "letta",
+    "source-claude",
+    "source-codex",
+    "source-gemini",
     "letta-claude",
     "letta-codex",
     "letta-gemini",
@@ -283,6 +287,10 @@ export function validateCreateAgentOptions(options: CreateAgentOptions): void {
     // Check if it's a preset name (if so, validate it)
     const validPresets = [
       "default",
+      "letta",
+      "source-claude",
+      "source-codex",
+      "source-gemini",
       "letta-claude",
       "letta-codex",
       "letta-gemini",


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

A custom string `systemPrompt` replaces the complete maintained harness prompt. Most runnable examples used that replacement form only to add a role, workflow, or response style. Those agents therefore lost the harness guidance for memory, skills, tools, and persistence.

The SDK already exposed a managed preset-with-append shape, but the shared agent-creation path no longer resolved it.

## Change

- Restore managed system-prompt preset and append resolution for Cloud, local, and remote agent creation.
- Align current preset IDs with Letta Code and retain deprecated aliases.
- Add an `instructions` field to the shared example helper. It appends each role to the default maintained harness.
- Migrate every runnable example role to the append path.
- Keep the SDK tour raw-string case as the explicit complete-replacement example.
- Keep `memory`, `persona`, and `human` deprecated.
- Leave the root README unchanged.

## Behavior

```ts
systemPrompt: {
  type: "preset",
  preset: "default",
  append: "You are a research analyst.",
}
```

This builds the current default harness for the selected memory mode, then adds the role instructions. A raw custom string remains a complete replacement.

## Validation

- `bun run check`
- `bun test` — 268 passed, 12 skipped, 0 failed
- `bun run build`
- Bundled all ten affected runnable entrypoints with `bun build --target bun`
- Local app-server acceptance: created an agent with the default MemFS harness plus a marker append, retrieved it, verified both contents, then deleted it.
- Cloud request test verifies that a managed preset reaches the REST boundary as the compiled harness prompt.
- Independent adversarial review found no material defect.
- `git diff --check`

## Limits

- Raw string prompts still replace the harness by design.
- The root README still uses that replacement form. Updating the headline quickstart is a separate content decision.
- Cloud and remote append behavior was not exercised against live services. They share the tested request builder; Cloud is also covered at its mocked REST boundary.

Linear: https://linear.app/letta/issue/LET-11921/track-agent-sdk-example-harness-preservation