### PR TITLE
feat(sessions): add runtime workspace sandbox options

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -98,6 +98,12 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
 
 export type AppServerSessionMode = RuntimeSessionMode;
 
+function workspaceSandboxOptions(
+  options: LettaCodeClientSessionOptions | CreateAgentOptions,
+): LettaCodeClientSessionOptions["workspaceSandbox"] {
+  return "workspaceSandbox" in options ? options.workspaceSandbox : undefined;
+}
+
 export function externalToolGroups(tools: AnyAgentTool[] | undefined): Array<Record<string, unknown>> | undefined {
   if (!tools || tools.length === 0) return undefined;
   return [
@@ -630,6 +636,18 @@ export class AppServerSession extends RemoteClientSessionCore {
 
     try {
       await client.connect();
+      const workspaceSandbox = workspaceSandboxOptions(options);
+      if (workspaceSandbox !== undefined) {
+        const info = await client.info();
+        const capabilities = info.capabilities as typeof info.capabilities & {
+          runtime_workspace_sandbox?: boolean;
+        };
+        if (capabilities.runtime_workspace_sandbox !== true) {
+          throw new Error(
+            "App server does not support runtime workspace sandboxing.",
+          );
+        }
+      }
       const response = await this.startRuntime(client);
       if (!response.success || !response.runtime) {
         throw new Error(response.error ?? "Failed to start app-server runtime");
@@ -730,6 +748,13 @@ export class AppServerSession extends RemoteClientSessionCore {
     const mode = mapPermissionMode(options.permissionMode);
     if (mode) command.mode = mode;
     if (options.cwd !== undefined) command.cwd = options.cwd;
+    const workspaceSandbox = workspaceSandboxOptions(options);
+    if (workspaceSandbox !== undefined) {
+      command.workspace_sandbox = {
+        root: workspaceSandbox.root,
+        isolation_root: workspaceSandbox.isolationRoot,
+      };
+    }
     if (
       this.mode.kind === "session" &&
       this.mode.options.stateless === true

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -78,6 +78,7 @@ function stripCloudExecutionOptions(
   delete sessionOptions.environment;
   delete sessionOptions.sandbox;
   delete sessionOptions.filesystemConfinement;
+  delete sessionOptions.workspaceSandbox;
   return sessionOptions;
 }
 
@@ -371,6 +372,14 @@ export class LettaAgentClientBase {
         `Invalid filesystemConfinement '${String(options.filesystemConfinement)}'. Valid value: memory.`,
       );
     }
+    if (
+      options.workspaceSandbox !== undefined &&
+      (!options.workspaceSandbox.root || !options.workspaceSandbox.isolationRoot)
+    ) {
+      throw new Error(
+        `${action}() workspaceSandbox requires non-empty root and isolationRoot paths.`,
+      );
+    }
     const effectiveComputer =
       options.computer ?? options.environment ?? this.computer;
     if (this.backend === "local") {
@@ -421,6 +430,11 @@ export class LettaAgentClientBase {
       if (options.filesystemConfinement !== undefined) {
         throw new Error(
           `${action}() filesystemConfinement is only supported with backend: "local".`,
+        );
+      }
+      if (options.workspaceSandbox !== undefined) {
+        throw new Error(
+          `${action}() workspaceSandbox is only supported by local and remote app servers.`,
         );
       }
       const cloudOptions = this.cloudOptions();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ import { LettaAgentClient } from "./client.js";
 import { connectMcpServers as connectNodeMcpServers } from "./mcp.js";
 import { registerMcpConnector } from "./mcp-runtime.js";
 
+export { startLocalAppServer } from "./local-app-server.js";
+export type {
+  LocalAppServerHandle,
+  StartLocalAppServerOptions,
+} from "./local-app-server.js";
+
 registerMcpConnector(connectNodeMcpServers);
 import type {
   CreateSessionOptions,

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -41,6 +41,7 @@ class FakeAppServerSocket {
     | "queuedSecond"
     | "hang" = "normal";
   static failNextRuntimeStart = false;
+  static supportsWorkspaceSandbox = true;
   static deferReflectionSettingsResponse = false;
   static failNextReflectionSettings = false;
   static pendingReflectionSettingsResponse: (() => void) | null = null;
@@ -172,6 +173,27 @@ function fakeAppServerHandle(
   // client's own pair so tests can run several client instances at once.
   const control = sender;
   const stream = fakeStreamPairOf(sender);
+
+  if (command.type === "app_server_info") {
+    control.serverMessage({
+      type: "app_server_info_response",
+      request_id: command.request_id,
+      success: true,
+      backend: "api",
+      letta_code_version: "test",
+      protocol_version: 1,
+      capabilities: {
+        agent_management: true,
+        conversation_management: true,
+        memory_management: true,
+        runtime_start: true,
+        runtime_workspace_sandbox:
+          FakeAppServerSocket.supportsWorkspaceSandbox,
+        split_channels: false,
+      },
+    });
+    return;
+  }
 
   if (command.type === "conversation_retrieve") {
     const conversationId = command.conversation_id as string;
@@ -801,6 +823,67 @@ describe("LettaAgentClient", () => {
         "unavailable in a stateless session",
       );
     } finally {
+      session.close();
+    }
+  });
+
+  test("sends a capability-gated runtime workspace sandbox", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+    const session = client.createSession("agent-123", {
+      cwd: "/tmp/runs/run-a",
+      workspaceSandbox: {
+        root: "/tmp/runs/run-a",
+        isolationRoot: "/tmp/runs",
+      },
+    });
+    try {
+      await asAdvanced(session).initialize();
+      expect(
+        fakeControlSocket().sent.map(
+          (command) => (command as { type: string }).type,
+        ),
+      ).toEqual(["app_server_info", "runtime_start"]);
+      expect(fakeControlSocket().sent[1]).toMatchObject({
+        workspace_sandbox: {
+          root: "/tmp/runs/run-a",
+          isolation_root: "/tmp/runs",
+        },
+      });
+    } finally {
+      session.close();
+    }
+  });
+
+  test("fails closed when the app server lacks workspace sandbox support", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.supportsWorkspaceSandbox = false;
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+    const session = client.createSession("agent-123", {
+      workspaceSandbox: {
+        root: "/tmp/runs/run-a",
+        isolationRoot: "/tmp/runs",
+      },
+    });
+    try {
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "does not support runtime workspace sandboxing",
+      );
+      expect(
+        fakeControlSocket().sent.map(
+          (command) => (command as { type: string }).type,
+        ),
+      ).toEqual(["app_server_info"]);
+    } finally {
+      FakeAppServerSocket.supportsWorkspaceSandbox = true;
       session.close();
     }
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -753,6 +753,15 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
    * management calls, and remote/Cloud runtimes.
    */
   filesystemConfinement?: "memory";
+  /**
+   * Constrain writes to one runtime-owned workspace while hiding peer
+   * workspaces under the same isolation root. Supported by local and remote
+   * app servers that advertise runtime workspace sandboxing.
+   */
+  workspaceSandbox?: {
+    root: string;
+    isolationRoot: string;
+  };
 }
 
 export interface LettaCodeSession extends AsyncDisposable {


### PR DESCRIPTION
## Summary
- expose runtime workspace sandbox roots in local and remote app-server session options
- capability-check the app server before sending `runtime_start.workspace_sandbox`
- fail closed against older harnesses that cannot enforce the boundary

## Validation
- `bun run check`
- `bun test` (267 passing, 12 live tests skipped)
- `bun run build`

Depends on letta-ai/letta-code#3827
Linear: LET-10975