### PR TITLE
docs(examples): modernize dungeon master

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,5 +1,6 @@
 # Generated state files
 **/state.json
+**/state.json.tmp
 **/seminar-state.json
 **/team-state.json
 
@@ -7,5 +8,6 @@
 **/output/
 **/transcripts/
 
-# Generated rulebooks (created by DM)
+# Generated Dungeon Master files
 **/rulebook.md
+/dungeon-master/campaigns/

--- a/examples/dungeon-master/README.md
+++ b/examples/dungeon-master/README.md
@@ -1,0 +1,189 @@
+# Persistent dungeon master
+
+This example uses one local Letta agent to run several tabletop campaigns. It saves the agent ID, resumes the same conversation, and keeps campaign state in readable Markdown files.
+
+The example teaches three SDK patterns:
+
+- Create an agent once, then resume it by ID.
+- Stream assistant text and tool calls from an interactive session.
+- Keep application state in files that you can inspect and edit.
+
+## Prerequisites
+
+You need the following items:
+
+- A checkout of this repository.
+- Bun 1.3.0, which is the package manager declared in `package.json`.
+- Valid credentials for the local backend's current default model.
+- Write access to this example directory.
+
+Install the repository dependencies from the repository root:
+
+```bash
+bun install
+```
+
+The example pins `backend: "local"`. It does not switch to Cloud when `LETTA_API_KEY` is set. The SDK selects the current default model for the local backend.
+
+## Run the example
+
+Run the CLI from the repository root:
+
+```bash
+bun examples/dungeon-master/cli.ts
+```
+
+`dm.ts` sets the session `cwd` to `examples/dungeon-master`. The agent and the CLI therefore use the same paths for `rulebook.md` and `campaigns/<name>/`.
+
+For a named campaign, skip the campaign-name prompt:
+
+```bash
+bun examples/dungeon-master/cli.ts --campaign=dragons
+```
+
+Enter actions or dialogue at the `>` prompt. Enter `save` to ask the agent to update the campaign files. Enter `quit` to ask for a final save and close the session.
+
+## Review the file-access warning
+
+`dm.ts` sets `permissionMode: "unrestricted"` and allows the `Read` and `Write` tools. The local app-server runs those tools on your machine without an approval prompt.
+
+The process has the same filesystem access as your user account. The tool allowlist prevents other client-side tools. The configured `cwd` gives relative paths a base directory, but it does not limit `Read` and `Write` to that directory.
+
+For an application that handles untrusted input, replace unrestricted mode with an approval flow. Implement `canUseTool` and approve each file path before the tool runs.
+
+## Follow the first run
+
+The first run follows this sequence:
+
+1. `loadState()` returns an empty state because `state.json` does not exist.
+2. The CLI validates the campaign name before it creates backend state.
+3. `createDM()` creates a local agent with MemFS enabled.
+4. `createDM()` stores the agent ID and resumes its default conversation.
+5. `initializeDM()` asks the agent to create `rulebook.md` with its game rules.
+6. The CLI records the campaign setup as pending, then creates its directory.
+7. The CLI asks the agent to start the campaign.
+8. The agent asks about the setting, tone, boundaries, and player character.
+9. After that turn succeeds, the CLI records the active campaign.
+10. Each player message starts another streamed agent turn.
+
+The host code creates `state.json` and the campaign directory. The agent creates and updates the Markdown content through `Write`. The next CLI command removes a campaign whose setup remained pending after an error or process interruption. Verify the files after the first save because the model controls each tool call.
+
+## Resume a later run
+
+Run the CLI again from the repository root:
+
+```bash
+bun examples/dungeon-master/cli.ts
+```
+
+The CLI reads the saved agent ID and calls `resumeSession(agentId)`. This call resumes the agent's default conversation. If `state.json` names an active campaign, the agent reads its files. The agent then recaps the last session and sets the next scene.
+
+Use the following commands to inspect or select saved state:
+
+```bash
+bun examples/dungeon-master/cli.ts --status
+bun examples/dungeon-master/cli.ts --list
+bun examples/dungeon-master/cli.ts --rulebook
+bun examples/dungeon-master/cli.ts --campaign=dragons
+bun examples/dungeon-master/cli.ts --new
+```
+
+`--campaign=dragons` resumes the directory if it exists. Otherwise, it starts a campaign with that name. `--new` prompts for a name and rejects a name that already exists.
+
+## Observe persistence
+
+The example has three state layers:
+
+| State | Where it lives | What it contains |
+| --- | --- | --- |
+| Agent state | Local Letta backend | Agent identity, system prompt, MemFS, and the default conversation |
+| CLI state | `state.json` | Agent ID, active campaign, and any setup in progress |
+| Game state | `rulebook.md` and `campaigns/` | Rules, world details, character state, quests, and session history |
+
+A generated directory can contain the following files:
+
+```text
+dungeon-master/
+├── state.json
+├── rulebook.md
+└── campaigns/
+    └── dragons/
+        ├── world.md
+        ├── player.md
+        ├── npcs.md
+        ├── quests.md
+        ├── session-log.md
+        └── consequences.md
+```
+
+The agent creates files when its prompts call for them. A new campaign starts as an empty directory, so some files can remain absent until play or a save requires them.
+
+Use this short exercise to check persistence:
+
+```bash
+bun examples/dungeon-master/cli.ts --campaign=dragons
+# Answer the setup questions, enter an action, then enter: save
+# Enter: quit
+
+bun examples/dungeon-master/cli.ts --status
+bun examples/dungeon-master/cli.ts --rulebook
+ls examples/dungeon-master/campaigns/dragons
+bun examples/dungeon-master/cli.ts --campaign=dragons
+```
+
+Compare the recap with `session-log.md`, `player.md`, and the other campaign files. Persistence is visible in the stored agent ID, resumed transcript, and saved files. Reusing an agent does not guarantee that later output will improve.
+
+## Distinguish the agent from the conversation
+
+An agent owns its identity, system prompt, and memory. A conversation owns one message history for that agent.
+
+This example stores only `dmAgentId`. Both the first run and later runs call `resumeSession(agentId)`, so every campaign uses the same default conversation. Starting a new campaign creates a new directory, not a new conversation.
+
+Use `client.createSession(agentId)` when each campaign needs a separate message history. After the session initializes, save its `conversationId` for that campaign. Resume the campaign later with `client.resumeSession(conversationId)`. The campaigns can still share one agent and its MemFS.
+
+## Understand where tools run
+
+`createExampleClient({ backend: "local" })` starts an SDK-owned Letta Code app-server on this machine. Its built-in `Read` and `Write` tools also run on this machine.
+
+The session allows only those two client-side tools. `chat()` sends one user message, then reads `session.stream()`. It prints assistant fragments as they arrive and prints a label when the agent calls a tool.
+
+The local agent is not available in the hosted chat UI. `--status` prints the local agent ID instead of a hosted-agent URL.
+
+## Reset the example
+
+Run the reset command and enter `yes` at the prompt:
+
+```bash
+bun examples/dungeon-master/cli.ts --reset
+```
+
+Reset deletes the following local paths under this example:
+
+- `state.json`
+- `rulebook.md`
+- `campaigns/`
+
+Reset does not delete the agent, its MemFS, or its conversation from the local backend. The next normal run creates a new agent and campaign directory because `state.json` no longer contains the old agent ID.
+
+## Read the code
+
+| File | Responsibility |
+| --- | --- |
+| `cli.ts` | Parses commands, selects a campaign, and owns the terminal input loop. |
+| `dm.ts` | Creates or resumes the agent, streams turns, and manages generated files. |
+| `types.ts` | Defines the saved state, generated paths, and campaign filenames. |
+| `../create-agent-session.ts` | Creates the SDK client, enables MemFS, and provides shared example helpers. |
+
+Start with `main()` in `cli.ts`. Then follow `createDM()` and `chat()` in `dm.ts`. These functions show the create, resume, send, and stream calls without a framework around them.
+
+## Extend the example
+
+The current structure supports the following changes:
+
+- **Select a model.** Add a configured model alias or handle to `DM_SESSION_OPTIONS` in `dm.ts`.
+- **Separate campaign transcripts.** Store a conversation ID for each campaign. Use `createSession(agentId)` for a new campaign and `resumeSession(conversationId)` later.
+- **Add a deterministic game tool.** Define a custom SDK tool for dice or card draws. Add the tool and its name to `DM_SESSION_OPTIONS`. The shared options apply after creation and on later resumes.
+- **Add a campaign file.** Add the filename to `CAMPAIGN_FILES` in `types.ts`. Update the save and resume prompts if the file needs a specific read or write trigger.
+- **Add approval controls.** Replace unrestricted mode and provide a `canUseTool` callback that validates each requested path.
+
+Keep campaign artifacts separate from agent memory. Campaign files hold the full game state. MemFS is better suited to durable cross-campaign preferences and short campaign pointers.

--- a/examples/dungeon-master/cli.ts
+++ b/examples/dungeon-master/cli.ts
@@ -1,55 +1,50 @@
 #!/usr/bin/env bun
 
 /**
- * Dungeon Master CLI
- * 
- * A persistent DM that creates its own game system and remembers your campaigns.
- * 
- * Usage:
- *   bun cli.ts                    # Continue current campaign or start new
- *   bun cli.ts --new              # Start a new campaign
- *   bun cli.ts --campaign=NAME    # Switch to a specific campaign
- *   bun cli.ts --list             # List all campaigns
- *   bun cli.ts --status           # Show DM and campaign status
- *   bun cli.ts --rulebook         # Display the DM's rulebook
- *   bun cli.ts --reset            # Delete local campaign state and start fresh
+ * Persistent Dungeon Master example.
+ *
+ * Run this file from the repository root:
+ *   bun examples/dungeon-master/cli.ts --help
  */
 
-import { parseArgs } from 'node:util';
 import * as readline from 'node:readline';
-import {
-  loadState,
-  saveState,
-  createDM,
-  initializeDM,
-  startNewCampaign,
-  resumeCampaign,
-  playSession,
-  showStatus,
-  resetAll,
-  hasRulebook,
-  readRulebook,
-  listCampaigns,
-} from './dm.js';
+import { parseArgs } from 'node:util';
 
-/**
- * Prompt user for input
- */
-function prompt(question: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
+import type { LettaCodeSession } from '../../src/index.js';
+import {
+  createDM,
+  hasRulebook,
+  initializeDM,
+  listCampaigns,
+  loadState,
+  normalizeCampaignName,
+  playSession,
+  readRulebook,
+  recoverPendingCampaign,
+  resetAll,
+  resumeCampaign,
+  showStatus,
+  startNewCampaign,
+} from './dm.js';
+import type { GameState } from './types.js';
+
+const COMMAND = 'bun examples/dungeon-master/cli.ts';
+const CAMPAIGN_NAME_COLLATOR = new Intl.Collator(undefined, {
+  sensitivity: 'accent',
+  usage: 'search',
+});
+
+interface CliOptions {
+  new: boolean;
+  campaign?: string;
+  list: boolean;
+  status: boolean;
+  rulebook: boolean;
+  reset: boolean;
+  help: boolean;
 }
 
-async function main() {
+function parseOptions(): CliOptions {
   const { values } = parseArgs({
     args: process.argv.slice(2),
     options: {
@@ -61,155 +56,229 @@ async function main() {
       reset: { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
     },
+    allowPositionals: false,
+    strict: true,
   });
 
-  if (values.help) {
+  return values;
+}
+
+function validateMode(options: CliOptions): void {
+  const selectedModes = [
+    options.new ? '--new' : null,
+    options.campaign !== undefined ? '--campaign' : null,
+    options.list ? '--list' : null,
+    options.status ? '--status' : null,
+    options.rulebook ? '--rulebook' : null,
+    options.reset ? '--reset' : null,
+  ].filter((mode): mode is string => mode !== null);
+
+  if (selectedModes.length > 1) {
+    throw new Error(`Choose one mode option. Received: ${selectedModes.join(', ')}.`);
+  }
+}
+
+function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function askForCampaignName(): Promise<string> {
+  return normalizeCampaignName(await prompt('Campaign name: '));
+}
+
+interface CampaignSelection {
+  name: string;
+  exists: boolean;
+}
+
+async function selectCampaign(
+  options: CliOptions,
+  state: GameState,
+): Promise<CampaignSelection> {
+  let campaignName: string;
+
+  if (options.new) {
+    campaignName = await askForCampaignName();
+  } else if (options.campaign !== undefined) {
+    campaignName = normalizeCampaignName(options.campaign);
+  } else if (state.activeCampaign) {
+    campaignName = state.activeCampaign;
+  } else {
+    console.log('\nNo active campaign exists. Create one to start playing.\n');
+    campaignName = await askForCampaignName();
+  }
+
+  const matchingNames = (await listCampaigns()).filter(
+    (name) => CAMPAIGN_NAME_COLLATOR.compare(name.normalize('NFC'), campaignName) === 0,
+  );
+  if (matchingNames.length > 1) {
+    throw new Error(
+      `Campaign name is ambiguous: ${matchingNames.map((name) => JSON.stringify(name)).join(', ')}.`,
+    );
+  }
+  const existingName = matchingNames[0];
+  if (options.new && existingName) {
+    throw new Error(
+      `Campaign ${JSON.stringify(existingName)} already exists. Use --campaign=${JSON.stringify(existingName)} to resume it.`,
+    );
+  }
+
+  return {
+    name: existingName ?? campaignName,
+    exists: existingName !== undefined,
+  };
+}
+
+async function openCampaign(
+  session: LettaCodeSession,
+  state: GameState,
+  selection: CampaignSelection,
+): Promise<void> {
+  if (selection.exists) {
+    await resumeCampaign(session, state, selection.name);
+  } else {
+    await startNewCampaign(session, state, selection.name);
+  }
+}
+
+async function runGame(options: CliOptions, state: GameState): Promise<void> {
+  // Resolve local input before creating or resuming an agent. Invalid input
+  // must not create backend state as a side effect.
+  const campaign = await selectCampaign(options, state);
+  const session = await createDM(state);
+
+  // A session owns a local app-server connection. Close it after normal play
+  // and after failures so that this short-lived CLI does not leak the process.
+  try {
+    if (!hasRulebook()) {
+      await initializeDM(session, state);
+    }
+
+    await openCampaign(session, state, campaign);
+    await playSession(session, campaign.name);
+  } finally {
+    session.close();
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions();
+  validateMode(options);
+
+  if (options.help) {
     printHelp();
     return;
   }
 
-  if (values.reset) {
-    const confirm = await prompt('⚠️  Delete DM and all campaigns? (yes/no): ');
-    if (confirm.toLowerCase() === 'yes') {
+  if (options.reset) {
+    const confirmation = await prompt(
+      'Delete local campaign files and forget the saved agent ID? The backend agent will remain. Type yes to continue: ',
+    );
+    if (confirmation.toLowerCase() === 'yes') {
       await resetAll();
     } else {
-      console.log('Cancelled.\n');
+      console.log('Reset cancelled.');
     }
     return;
   }
 
-  if (values.status) {
-    const state = await loadState();
+  if (options.rulebook) {
+    const rulebook = await readRulebook();
+    if (rulebook) {
+      console.log('\nDungeon Master rulebook:\n');
+      console.log(rulebook);
+    } else {
+      console.log(`\nNo rulebook exists. Run ${COMMAND} to create one.\n`);
+    }
+    return;
+  }
+
+  const state = await loadState();
+  await recoverPendingCampaign(state);
+
+  if (options.status) {
     await showStatus(state);
     return;
   }
 
-  if (values.list) {
+  if (options.list) {
     const campaigns = await listCampaigns();
-    console.log('\n📜 Campaigns:\n');
+    console.log('\nCampaigns:\n');
     if (campaigns.length === 0) {
-      console.log('  (no campaigns yet)\n');
-    } else {
-      for (const name of campaigns) {
-        console.log(`  - ${name}`);
-      }
-      console.log('');
+      console.log('  (none)\n');
+      return;
     }
+    for (const name of campaigns) {
+      console.log(`  - ${name}`);
+    }
+    console.log('');
     return;
   }
 
-  if (values.rulebook) {
-    const rulebook = await readRulebook();
-    if (rulebook) {
-      console.log('\n📖 DM\'s Rulebook:\n');
-      console.log(rulebook);
-    } else {
-      console.log('\n📖 No rulebook yet. Start a session to have the DM create one.\n');
-    }
-    return;
-  }
-
-  // Main game flow
-  const state = await loadState();
-  
-  // Create or resume DM
-  const dm = await createDM(state);
-  
-  // Save DM ID if new
-  if (!state.dmAgentId && dm.agentId) {
-    state.dmAgentId = dm.agentId;
-    await saveState(state);
-  }
-  
-  // If no rulebook, initialize the DM first
-  if (!hasRulebook()) {
-    await initializeDM(dm, state);
-  }
-  
-  // Determine what to do
-  if (values.new || values.campaign) {
-    // Starting or switching campaigns
-    const campaignName = values.campaign || await prompt('📜 Campaign name: ');
-    if (!campaignName) {
-      console.log('No campaign name provided.\n');
-      dm.close();
-      return;
-    }
-    
-    const campaigns = await listCampaigns();
-    if (campaigns.includes(campaignName)) {
-      // Resume existing
-      await resumeCampaign(dm, state, campaignName);
-    } else {
-      // Start new
-      await startNewCampaign(dm, state, campaignName);
-    }
-  } else if (state.activeCampaign) {
-    // Resume current campaign
-    await resumeCampaign(dm, state, state.activeCampaign);
-  } else {
-    // No active campaign, start new
-    console.log('\n🎲 Welcome to Dungeon Master!\n');
-    console.log('No active campaign. Let\'s start one.\n');
-    
-    const campaignName = await prompt('📜 Campaign name: ');
-    if (!campaignName) {
-      console.log('No campaign name provided.\n');
-      dm.close();
-      return;
-    }
-    
-    await startNewCampaign(dm, state, campaignName);
-  }
-  
-  // Enter gameplay loop
-  await playSession(dm);
-  
-  dm.close();
+  await runGame(options, state);
 }
 
-function printHelp() {
+function printHelp(): void {
   console.log(`
-🎲 Dungeon Master
+Dungeon Master example
 
-A persistent DM that creates its own game system and remembers your campaigns.
+Runs one persistent local agent as a tabletop role-playing game Dungeon Master.
+The agent writes the game rules and campaign state to files you can inspect.
 
-USAGE:
-  bun cli.ts [options]
+Usage:
+  ${COMMAND} [mode]
 
-OPTIONS:
-  --new              Start a new campaign
-  --campaign=NAME    Switch to or create a specific campaign
-  --list             List all campaigns
-  --status           Show DM and campaign status
-  --rulebook         Display the DM's custom rulebook
-  --reset            Delete local campaign state and start fresh
+Modes (choose one):
+  --new              Prompt for a new campaign name
+  --campaign=NAME    Resume NAME, or create it when it does not exist
+  --list             List campaign directories
+  --status           Show the saved agent ID and active campaign
+  --rulebook         Print the generated rulebook
+  --reset            Delete generated files and forget the saved agent ID
   -h, --help         Show this help
 
-EXAMPLES:
-  bun cli.ts                      # Continue current campaign
-  bun cli.ts --new                # Start a new campaign
-  bun cli.ts --campaign=dragons   # Play the "dragons" campaign
-  bun cli.ts --rulebook           # See the DM's game system
+Examples:
+  ${COMMAND}
+  ${COMMAND} --new
+  ${COMMAND} --campaign=dragons
+  ${COMMAND} --status
 
-FEATURES:
-  📖 The DM writes its own rulebook - a custom game system it creates and refines
-  🗺️  Persistent campaigns - come back days later and pick up where you left off
-  👥 NPCs remember you - "You're the one who spared the goblin!"
-  ⚡ Consequences matter - past actions shape future events
-  🎭 Collaborative tone - the DM adapts to what you enjoy
+During play:
+  save                Ask the agent to update the campaign files
+  quit or exit        Save the campaign files and end the session
 
-GAMEPLAY:
-  Type your actions, dialogue, or questions. The DM will respond.
-  
-  Special commands:
-    save  - Save current progress
-    quit  - End session (auto-saves)
+Generated files:
+  examples/dungeon-master/state.json
+      Stores the agent ID, active campaign, and any setup in progress.
+  examples/dungeon-master/rulebook.md
+      Stores the game system that the agent creates.
+  examples/dungeon-master/campaigns/<name>/
+      Stores the world, character, quests, NPCs, consequences, and session log.
 
-Each campaign is stored in campaigns/{name}/ with files for world, character,
-NPCs, quests, and session history. The DM reads and writes these files to keep
-campaign context across sessions.
+Persistence:
+  The local backend stores the agent and its default conversation. The files
+  above store game state in a form that you can read and edit. --reset removes
+  the files and saved ID, but it does not delete the backend agent.
+
+Safety:
+  The session gives the agent Read and Write tools in unrestricted permission
+  mode. This example sets their working directory to examples/dungeon-master,
+  but it does not sandbox file access.
 `);
 }
 
-main().catch(console.error);
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  process.exitCode = 1;
+});

--- a/examples/dungeon-master/dm.ts
+++ b/examples/dungeon-master/dm.ts
@@ -1,25 +1,50 @@
-/**
- * Dungeon Master Agent
- * 
- * A persistent DM that creates its own game system and runs campaigns.
- */
+/** A persistent Dungeon Master with file-backed campaign state. */
 
-import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { type LettaCodeSession } from '../../src/index.js';
-import { createAgentSession, createExampleClient, formatAgentLink, resumeExampleSession } from '../create-agent-session.js';
-import { CAMPAIGN_FILES, DEFAULT_CONFIG, PATHS, type GameState } from './types.js';
+import {
+  type LettaCodeClientSessionOptions,
+  type LettaCodeSession,
+} from '../../src/index.js';
+import {
+  createExampleAgent,
+  createExampleClient,
+  formatAgentLink,
+  resumeExampleSession,
+} from '../create-agent-session.js';
+import { CAMPAIGN_FILES, PATHS, type GameState } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const STATE_FILE = join(__dirname, PATHS.stateFile);
+const STATE_TEMP_FILE = `${STATE_FILE}.tmp`;
 const RULEBOOK_FILE = join(__dirname, PATHS.rulebook);
 const CAMPAIGNS_DIR = join(__dirname, PATHS.campaignsDir);
 const client = createExampleClient({ backend: 'local' });
+const INVALID_CAMPAIGN_NAME_CHARACTERS = /[<>:"/\\|?*\u0000-\u001F]/;
+const WINDOWS_RESERVED_NAME = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\..*)?$/i;
+
+// Setting cwd makes the agent's relative Read and Write paths match the files
+// that this CLI inspects. The allowlist keeps unrelated client tools disabled.
+const DM_SESSION_OPTIONS = {
+  allowedTools: ['Read', 'Write'],
+  permissionMode: 'unrestricted',
+  cwd: __dirname,
+  skillSources: [],
+} satisfies LettaCodeClientSessionOptions;
+
+const CAMPAIGN_FILE_GUIDE = [
+  `${CAMPAIGN_FILES.world} - Setting, locations, and lore`,
+  `${CAMPAIGN_FILES.player} - Character sheet, backstory, and inventory`,
+  `${CAMPAIGN_FILES.npcs} - Non-player characters and relationships`,
+  `${CAMPAIGN_FILES.quests} - Active and completed quests`,
+  `${CAMPAIGN_FILES.sessionLog} - Session summaries`,
+  `${CAMPAIGN_FILES.consequences} - Pending results of earlier choices`,
+].map((line) => `  - ${line}`).join('\n');
 
 // ANSI colors
 const COLORS = {
@@ -29,40 +54,83 @@ const COLORS = {
   reset: '\x1b[0m',
 };
 
-/**
- * Load game state from disk
- */
-export async function loadState(): Promise<GameState> {
-  if (existsSync(STATE_FILE)) {
-    const data = await readFile(STATE_FILE, 'utf-8');
-    return JSON.parse(data);
+function parseState(value: unknown): GameState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${PATHS.stateFile} must contain a JSON object.`);
   }
-  return {
-    dmAgentId: null,
-    activeCampaign: null,
-    campaigns: [],
-  };
+
+  const state = value as Record<string, unknown>;
+  const dmAgentId = state.dmAgentId;
+  const activeCampaign = state.activeCampaign;
+  const pendingCampaign = state.pendingCampaign ?? null;
+  if (dmAgentId !== null && typeof dmAgentId !== 'string') {
+    throw new Error(`${PATHS.stateFile} has an invalid dmAgentId.`);
+  }
+  if (activeCampaign !== null && typeof activeCampaign !== 'string') {
+    throw new Error(`${PATHS.stateFile} has an invalid activeCampaign.`);
+  }
+  if (pendingCampaign !== null && typeof pendingCampaign !== 'string') {
+    throw new Error(`${PATHS.stateFile} has an invalid pendingCampaign.`);
+  }
+  if (activeCampaign) validateCampaignName(activeCampaign);
+  if (pendingCampaign) validateCampaignName(pendingCampaign);
+
+  return { dmAgentId, activeCampaign, pendingCampaign };
 }
 
-/**
- * Save game state to disk
- */
+export async function loadState(): Promise<GameState> {
+  if (!existsSync(STATE_FILE)) {
+    return { dmAgentId: null, activeCampaign: null, pendingCampaign: null };
+  }
+
+  try {
+    return parseState(JSON.parse(await readFile(STATE_FILE, 'utf-8')));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot load ${PATHS.stateFile}: ${detail}`);
+  }
+}
+
 export async function saveState(state: GameState): Promise<void> {
-  await writeFile(STATE_FILE, JSON.stringify(state, null, 2));
+  await writeFile(STATE_TEMP_FILE, `${JSON.stringify(state, null, 2)}\n`);
+  await rename(STATE_TEMP_FILE, STATE_FILE);
 }
 
-/**
- * Get campaign directory path
- */
+function validateCampaignName(campaignName: string): void {
+  const valid =
+    campaignName.length > 0 &&
+    campaignName.length <= 64 &&
+    campaignName === campaignName.trim() &&
+    campaignName !== '.' &&
+    campaignName !== '..' &&
+    !campaignName.endsWith('.') &&
+    !INVALID_CAMPAIGN_NAME_CHARACTERS.test(campaignName) &&
+    !WINDOWS_RESERVED_NAME.test(campaignName);
+  if (!valid) {
+    throw new Error(
+      'Campaign name must be 1-64 characters and valid as a directory name on macOS, Linux, and Windows.',
+    );
+  }
+}
+
+export function normalizeCampaignName(value: string): string {
+  const campaignName = value.trim().normalize('NFC');
+  validateCampaignName(campaignName);
+  return campaignName;
+}
+
 function getCampaignDir(campaignName: string): string {
-  return join(CAMPAIGNS_DIR, campaignName);
+  validateCampaignName(campaignName);
+  const campaignDir = resolve(CAMPAIGNS_DIR, campaignName);
+  if (!campaignDir.startsWith(`${CAMPAIGNS_DIR}${sep}`)) {
+    throw new Error('Campaign path must stay inside the campaigns directory.');
+  }
+  return campaignDir;
 }
 
-/**
- * Get campaign file path
- */
-function getCampaignFile(campaignName: string, file: keyof typeof CAMPAIGN_FILES): string {
-  return join(getCampaignDir(campaignName), CAMPAIGN_FILES[file]);
+function getCampaignRelativePath(campaignName: string): string {
+  validateCampaignName(campaignName);
+  return `${PATHS.campaignsDir}/${campaignName}`;
 }
 
 /**
@@ -86,267 +154,285 @@ export async function readRulebook(): Promise<string | null> {
 export async function listCampaigns(): Promise<string[]> {
   if (!existsSync(CAMPAIGNS_DIR)) return [];
   const entries = await readdir(CAMPAIGNS_DIR, { withFileTypes: true });
-  return entries.filter(e => e.isDirectory()).map(e => e.name);
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
 }
 
-/**
- * Create or resume the DM agent
- */
+/** Remove a campaign whose setup did not reach the state-file commit. */
+export async function recoverPendingCampaign(state: GameState): Promise<void> {
+  if (!state.pendingCampaign) return;
+
+  const pendingCampaign = state.pendingCampaign;
+  await rm(getCampaignDir(pendingCampaign), { force: true, recursive: true });
+  state.pendingCampaign = null;
+  await saveState(state);
+  console.log(
+    `${COLORS.system}Removed incomplete campaign setup: ${pendingCampaign}${COLORS.reset}`,
+  );
+}
+
+/** Resume the saved agent's default conversation, or create it once. */
 export async function createDM(state: GameState): Promise<LettaCodeSession> {
   if (state.dmAgentId) {
-    // Resume existing DM
-    return resumeExampleSession(state.dmAgentId, {
-      model: DEFAULT_CONFIG.model,
-      allowedTools: ['Read', 'Write'],
-      permissionMode: 'unrestricted',
-    }, client);
+    return resumeExampleSession(state.dmAgentId, DM_SESSION_OPTIONS, client);
   }
 
-  // Create new DM
-  const session = await createAgentSession({
-    model: DEFAULT_CONFIG.model,
-    systemPrompt: `You are a Dungeon Master - a creative storyteller and game designer who runs tabletop RPG campaigns.
+  // The SDK selects its current default model when `model` is omitted. Saving
+  // the agent ID before the first turn lets a failed setup resume on retry.
+  const agentId = await createExampleAgent({
+    name: 'Dungeon Master',
+    description: 'Runs file-backed tabletop role-playing campaigns.',
+    baseTools: [],
+    systemPrompt: `You are a Dungeon Master who designs and runs tabletop role-playing campaigns.
 
-## Your Role
-- Design and run engaging tabletop RPG experiences
-- Create your own game system with rules you write in rulebook.md
-- Manage persistent campaign worlds that remember everything
-- Collaborate with players on tone, style, and what kind of experience they want
+## Role
+- Create a small game system in ${PATHS.rulebook}.
+- Run campaigns whose state later sessions can read from files.
+- Ask the player about tone, boundaries, and character goals.
 
-## Your Style
-- Adapt to what the player wants (serious, funny, dark, lighthearted)
-- Be descriptive and immersive in narration
-- Give players meaningful choices with real consequences
-- Keep things moving - don't get bogged down in rules
+## Style
+- Match the tone that the player requests.
+- Describe scenes with enough detail to support a choice.
+- Give choices consequences that follow from the saved campaign state.
+- Prefer a clear ruling over a long rules discussion.
 
-## File Management
-You have access to Read and Write tools. Use them to:
-- Write and update your rulebook (rulebook.md)
-- Manage campaign files in campaigns/{name}/:
-  - world.md - Setting, locations, lore
-  - player.md - Character sheet, backstory, inventory
-  - npcs.md - NPCs met, relationships
-  - quests.md - Active/completed quests
-  - session-log.md - What happened each session
-  - consequences.md - Pending events from past actions
+## Files
+The working directory is this example directory. Use relative paths only.
+Write the shared rules to ${PATHS.rulebook}. Store each campaign under
+${PATHS.campaignsDir}/{name}/ with these files:
+${CAMPAIGN_FILE_GUIDE}
 
-## Memory Files
-Keep cross-campaign player preferences in reference/player-preferences.md and
-brief campaign pointers in reference/campaign-index.md. Keep full campaign
-state in the campaign files above.
+Keep full campaign state in those campaign files. Store only durable,
+cross-campaign player preferences in the agent's memory files. Do not store
+secrets in campaign or memory files.
 
-## Important
-- Always update campaign files after significant events
-- Reference your rulebook when resolving actions
-- Make the world feel alive and reactive to player choices`,
-    allowedTools: ['Read', 'Write'],
-    permissionMode: 'unrestricted',
+Read ${PATHS.rulebook} before you resolve an uncertain action. Update the active
+campaign files after events that change the world, character, quests, or future
+consequences. Never write one campaign's state into another campaign.`,
   }, client);
 
-  return session;
+  state.dmAgentId = agentId;
+  await saveState(state);
+  return resumeExampleSession(agentId, DM_SESSION_OPTIONS, client);
 }
 
-/**
- * Stream output with color
- */
 function createStreamPrinter(): (text: string) => void {
   return (text: string) => {
     process.stdout.write(`${COLORS.dm}${text}${COLORS.reset}`);
   };
 }
 
-/**
- * Send a message to the DM and get response
- */
+/** Send one turn, print assistant fragments, and require a terminal result. */
 export async function chat(
   session: LettaCodeSession,
   message: string,
-  onOutput?: (text: string) => void
+  onOutput?: (text: string) => void,
 ): Promise<string> {
   await session.send(message);
-  
-  let response = '';
-  const printer = onOutput || createStreamPrinter();
-  
-  let lastToolName = '';
+
+  let streamedResponse = '';
+  let streamedError: string | undefined;
+  const printedToolCalls = new Set<string>();
+  const printer = onOutput ?? createStreamPrinter();
+
   for await (const msg of session.stream()) {
     if (msg.type === 'assistant') {
-      response += msg.content;
+      streamedResponse += msg.content;
       printer(msg.content);
-      lastToolName = '';
-    } else if (msg.type === 'tool_call' && 'toolName' in msg) {
-      if (msg.toolName !== lastToolName) {
-        console.log(`\n${COLORS.system}[${msg.toolName}]${COLORS.reset}`);
-        lastToolName = msg.toolName;
+      continue;
+    }
+
+    if (msg.type === 'tool_call' && !printedToolCalls.has(msg.toolCallId)) {
+      printedToolCalls.add(msg.toolCallId);
+      console.log(`\n${COLORS.system}[${msg.toolName}]${COLORS.reset}`);
+      continue;
+    }
+
+    if (msg.type === 'error') {
+      streamedError = msg.errorDetail ?? msg.message;
+      continue;
+    }
+
+    if (msg.type === 'result') {
+      if (!msg.success) {
+        throw new Error(
+          streamedError ?? msg.errorDetail ?? msg.error ?? msg.errorCode ?? 'Dungeon Master turn failed.',
+        );
       }
+
+      const completeResponse = msg.result ?? streamedResponse;
+      // Some transports provide only the complete text on the result message.
+      if (!streamedResponse && completeResponse) printer(completeResponse);
+      return completeResponse;
     }
   }
-  
-  return response;
+
+  throw new Error('Dungeon Master stream ended before a terminal result.');
 }
 
-/**
- * Initialize a new DM (create rulebook)
- */
-export async function initializeDM(session: LettaCodeSession, state: GameState): Promise<void> {
+/** Ask a new agent to create the rulebook that the CLI will inspect. */
+export async function initializeDM(
+  session: LettaCodeSession,
+  state: GameState,
+): Promise<void> {
   console.log(`\n${COLORS.system}The DM is creating its game system...${COLORS.reset}\n`);
-  
-  const prompt = `You're starting fresh as a Dungeon Master. Your first task is to create your game system.
 
-Write a rulebook.md file that contains your custom tabletop RPG rules. Include:
+  const prompt = `Create ${PATHS.rulebook} in the current working directory. Define a small tabletop role-playing game with:
 
-1. **Core Mechanic** - How do players resolve actions? (dice, cards, narrative, etc.)
-2. **Character Stats** - What defines a character mechanically?
-3. **Combat** - How does fighting work?
-4. **Skills/Abilities** - What can characters do?
-5. **Progression** - How do characters grow?
-6. **Health/Death** - How does damage and dying work?
+1. A core action-resolution mechanic.
+2. Character statistics.
+3. Combat rules.
+4. Skills or abilities.
+5. Character progression.
+6. Damage, recovery, and death rules.
 
-Keep it simple but complete enough to run a game. You can always refine it later.
-
-Use the Write tool to create rulebook.md now.`;
+Keep the rules short enough to use during play. Use the Write tool now.`;
 
   await chat(session, prompt, createStreamPrinter());
-  
-  // Save the DM agent ID
-  if (session.agentId) {
-    state.dmAgentId = session.agentId;
-    await saveState(state);
+  if (!hasRulebook()) {
+    throw new Error(`The turn completed without creating ${PATHS.rulebook}.`);
   }
-  
-  console.log(`\n\n${COLORS.system}Rulebook created! The DM is ready.${COLORS.reset}`);
-  console.log(`${COLORS.system}[DM Agent: ${session.agentId}]${COLORS.reset}`);
-  console.log(`${COLORS.system}[→ ${formatAgentLink(session.agentId, client)}]${COLORS.reset}\n`);
+
+  const agentId = session.agentId ?? state.dmAgentId;
+  if (!agentId) throw new Error('The session did not report a Dungeon Master agent ID.');
+
+  console.log(`\n\n${COLORS.system}Rulebook created. The DM is ready.${COLORS.reset}`);
+  console.log(`${COLORS.system}[DM Agent: ${agentId}]${COLORS.reset}`);
+  console.log(`${COLORS.system}[→ ${formatAgentLink(agentId, client)}]${COLORS.reset}\n`);
 }
 
-/**
- * Start a new campaign
- */
+/** Create the campaign directory and begin play in the saved conversation. */
 export async function startNewCampaign(
   session: LettaCodeSession,
   state: GameState,
-  campaignName: string
+  campaignName: string,
 ): Promise<void> {
-  // Create campaign directory
-  const campaignDir = getCampaignDir(campaignName);
-  await mkdir(campaignDir, { recursive: true });
-  
-  // Update state
-  state.activeCampaign = campaignName;
-  if (!state.campaigns.includes(campaignName)) {
-    state.campaigns.push(campaignName);
+  const normalizedName = normalizeCampaignName(campaignName);
+  const campaignDir = getCampaignDir(normalizedName);
+  const campaignPath = getCampaignRelativePath(normalizedName);
+  if (existsSync(campaignDir)) {
+    throw new Error(`Campaign ${JSON.stringify(normalizedName)} already exists.`);
   }
+
+  state.pendingCampaign = normalizedName;
   await saveState(state);
-  
-  console.log(`\n${COLORS.system}Starting new campaign: ${campaignName}${COLORS.reset}\n`);
-  
-  const prompt = `We're starting a new campaign called "${campaignName}".
+  console.log(`\n${COLORS.system}Starting new campaign: ${normalizedName}${COLORS.reset}\n`);
 
-The campaign files are in: campaigns/${campaignName}/
+  const prompt = `Start the new campaign ${JSON.stringify(normalizedName)}. Store its files only under ${campaignPath}/.
 
-First, let's create this world together. Ask me:
-1. What kind of setting/world interests me?
-2. What tone am I looking for? (serious, comedic, dark, heroic, etc.)
-3. Any topics I'd like to avoid?
+Ask the player the following questions:
+1. What setting interests them?
+2. What tone do they want?
+3. What topics do they want to exclude?
+4. What character do they want to play?
 
-Then ask about my character concept - I'll describe who I want to play and you'll help fill in the mechanical details based on your rulebook.
+Use ${PATHS.rulebook} to help with the character's mechanical details. Begin with a short greeting and the questions.`;
 
-Start by greeting me and asking these questions.`;
-
-  await chat(session, prompt, createStreamPrinter());
+  try {
+    await mkdir(campaignDir, { recursive: true });
+    await chat(session, prompt, createStreamPrinter());
+    state.activeCampaign = normalizedName;
+    state.pendingCampaign = null;
+    await saveState(state);
+  } catch (error) {
+    await rm(campaignDir, { force: true, recursive: true });
+    state.pendingCampaign = null;
+    await saveState(state);
+    throw error;
+  }
   console.log('\n');
 }
 
-/**
- * Resume an existing campaign
- */
+/** Resume a campaign after the agent reloads its file-backed state. */
 export async function resumeCampaign(
   session: LettaCodeSession,
   state: GameState,
-  campaignName: string
+  campaignName: string,
 ): Promise<void> {
+  validateCampaignName(campaignName);
+  const campaignDir = getCampaignDir(campaignName);
+  const campaignPath = getCampaignRelativePath(campaignName);
+  if (!existsSync(campaignDir)) {
+    throw new Error(`Campaign ${JSON.stringify(campaignName)} does not exist.`);
+  }
+
   state.activeCampaign = campaignName;
   await saveState(state);
-  
+
   console.log(`\n${COLORS.system}Resuming campaign: ${campaignName}${COLORS.reset}\n`);
-  
-  const prompt = `We're resuming the campaign "${campaignName}".
 
-Please:
-1. Read the campaign files in campaigns/${campaignName}/ to refresh your memory
-2. Read your rulebook.md if needed
-3. Give me a brief recap of where we left off
-4. Set the scene for our next moment of play
+  const prompt = `Resume the campaign ${JSON.stringify(campaignName)}.
 
-Use the Read tool to load the campaign state, then continue our adventure.`;
+1. Read the available files under ${campaignPath}/.
+2. Read ${PATHS.rulebook} if you need to resolve an action.
+3. Give the player a short recap based only on saved campaign state.
+4. Set the next scene.
+
+Keep all updates for this campaign under ${campaignPath}/.`;
 
   await chat(session, prompt, createStreamPrinter());
   console.log('\n');
 }
 
-/**
- * Main gameplay loop
- */
-export async function playSession(session: LettaCodeSession): Promise<void> {
+/** Run the interactive player loop for one campaign. */
+export async function playSession(
+  session: LettaCodeSession,
+  campaignName: string,
+): Promise<void> {
   const readline = await import('node:readline');
-  
+  const campaignPath = getCampaignRelativePath(campaignName);
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-  
-  const askQuestion = (prompt: string): Promise<string> => {
-    return new Promise((resolve) => {
-      rl.question(prompt, (answer) => {
-        resolve(answer);
-      });
-    });
-  };
-  
+
+  const inputLines = rl[Symbol.asyncIterator]();
   console.log(`${COLORS.system}(Type 'quit' to end session, 'save' to save progress)${COLORS.reset}\n`);
-  
-  while (true) {
-    const input = await askQuestion(`${COLORS.player}> ${COLORS.reset}`);
-    
-    if (input.toLowerCase() === 'quit' || input.toLowerCase() === 'exit') {
-      // Ask DM to save state
-      console.log(`\n${COLORS.system}Ending session...${COLORS.reset}\n`);
-      await chat(session, `The player is ending the session. Please:
-1. Update the session-log.md with a summary of what happened this session
-2. Update any other campaign files that need changes (player.md, npcs.md, quests.md, consequences.md)
-3. Give a brief farewell that hints at what might come next
 
-Use the Write tool to save everything.`, createStreamPrinter());
-      console.log('\n');
-      break;
-    }
-    
-    if (input.toLowerCase() === 'save') {
-      console.log(`\n${COLORS.system}Saving progress...${COLORS.reset}\n`);
-      await chat(session, `Please save the current game state:
-1. Update session-log.md with recent events
-2. Update player.md with any changes to the character
-3. Update any other files that need it
+  try {
+    while (true) {
+      process.stdout.write(`${COLORS.player}> ${COLORS.reset}`);
+      const nextInput = await inputLines.next();
+      if (nextInput.done) break;
+      const input = nextInput.value;
+      const command = input.trim().toLowerCase();
 
-Use the Write tool to save.`, createStreamPrinter());
+      if (command === 'quit' || command === 'exit') {
+        console.log(`\n${COLORS.system}Ending session...${COLORS.reset}\n`);
+        await chat(session, `The player is ending the session.
+
+1. Summarize this session in ${campaignPath}/${CAMPAIGN_FILES.sessionLog}.
+2. Update any changed files under ${campaignPath}/.
+3. Give the player a short farewell with one possible next development.
+
+Use the Write tool for the file updates.`, createStreamPrinter());
+        console.log('\n');
+        break;
+      }
+
+      if (command === 'save') {
+        console.log(`\n${COLORS.system}Saving progress...${COLORS.reset}\n`);
+        await chat(session, `Save the current campaign state under ${campaignPath}/.
+
+Update ${CAMPAIGN_FILES.sessionLog} and each other campaign file whose state changed. Do not write campaign state outside ${campaignPath}/.`, createStreamPrinter());
+        console.log('\n');
+        continue;
+      }
+
+      if (!input.trim()) continue;
+
+      console.log('');
+      await chat(session, input, createStreamPrinter());
       console.log('\n');
-      continue;
     }
-    
-    if (!input.trim()) continue;
-    
-    // Send player input to DM
-    console.log('');
-    await chat(session, input, createStreamPrinter());
-    console.log('\n');
+  } finally {
+    rl.close();
   }
-  
-  rl.close();
 }
 
-/**
- * Show game status
- */
 export async function showStatus(state: GameState): Promise<void> {
   console.log('\n🎲 Dungeon Master Status\n');
   
@@ -373,22 +459,12 @@ export async function showStatus(state: GameState): Promise<void> {
   console.log('');
 }
 
-/**
- * Reset everything
- */
+/** Delete generated files without deleting the persisted backend agent. */
 export async function resetAll(): Promise<void> {
-  const fs = await import('node:fs/promises');
-  
-  if (existsSync(STATE_FILE)) {
-    await fs.unlink(STATE_FILE);
-  }
-  if (existsSync(RULEBOOK_FILE)) {
-    await fs.unlink(RULEBOOK_FILE);
-  }
-  if (existsSync(CAMPAIGNS_DIR)) {
-    await fs.rm(CAMPAIGNS_DIR, { recursive: true });
-    await mkdir(CAMPAIGNS_DIR);
-  }
-  
+  await rm(STATE_FILE, { force: true });
+  await rm(STATE_TEMP_FILE, { force: true });
+  await rm(RULEBOOK_FILE, { force: true });
+  await rm(CAMPAIGNS_DIR, { force: true, recursive: true });
+
   console.log('\nLocal state and campaign files deleted. The agent still exists in the local backend.\n');
 }

--- a/examples/dungeon-master/types.ts
+++ b/examples/dungeon-master/types.ts
@@ -1,20 +1,9 @@
-/**
- * Dungeon Master Types
- */
-
+/** State that the CLI needs to resume the same agent and campaign. */
 export interface GameState {
   dmAgentId: string | null;
   activeCampaign: string | null;
-  campaigns: string[];
+  pendingCampaign: string | null;
 }
-
-export interface DMConfig {
-  model: string;
-}
-
-export const DEFAULT_CONFIG: DMConfig = {
-  model: 'haiku',
-};
 
 export const PATHS = {
   stateFile: 'state.json',


### PR DESCRIPTION
## What

- Add a runnable README for the persistent Dungeon Master example.
- Use the current SDK model, session, stream, tool, and MemFS contracts.
- Keep campaign files under one known working directory and validate campaign names across macOS, Linux, and Windows.
- Preserve safe legacy campaign names and recover campaign setup after errors or process interruption.
- Improve CLI help, mode validation, session cleanup, generated-file ignores, and piped input handling.

## Why

The example directory had no guide, and several details could teach the wrong pattern. It pinned a stale model alias, accepted stream completion without a terminal result, trusted campaign names as paths, and could treat partial setup as a resumable campaign.

The revised example makes persistence visible across the agent, its default conversation, `state.json`, and readable campaign files. The README also states where tools execute and why unrestricted file access needs care.

## Limits and risk

- The example remains local-backend only.
- `Read` and `Write` run with the SDK process permissions. Setting `cwd` does not sandbox them.
- `--reset` removes generated files and the saved agent ID. It does not delete the backend agent.
- Changes are limited to `examples/dungeon-master/` and generated-file ignores.

## Testing

- `bun run check`
- `bun test` — 265 pass, 12 skip, 0 fail
- `bun run build`
- `bun build examples/dungeon-master/cli.ts --target bun`
- Real CLI acceptance through the local app-server and a live model: create the agent and rulebook, start and resume a campaign, send player input, run `save`, run `quit`, inspect all generated files, then reset and delete the smoke-test agent.
- Compatibility checks for interrupted setup, failed setup rollback, Unicode and punctuation in legacy campaign names, case-insensitive name collisions, unsafe paths, and generated-file ignores.

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)