### PR TITLE
fix: preserve trailing usage before remote turn result

### DIFF
--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -139,6 +139,7 @@ export type TurnTracker = {
   runIds: Set<string>;
   observedTurnEvidence: boolean;
   observedRequiresApprovalStop: boolean;
+  pendingTerminal: RuntimeTurnResult | null;
   abortRequested: boolean;
   timeout: ReturnType<typeof setTimeout> | null;
 };

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -101,6 +101,7 @@ export class RemoteTurnCoordinator {
       runIds: new Set<string>(),
       observedTurnEvidence: false,
       observedRequiresApprovalStop: false,
+      pendingTerminal: null,
       abortRequested: false,
       timeout: null,
     };
@@ -332,6 +333,7 @@ export class RemoteTurnCoordinator {
       return;
     }
     if (status === "WAITING_ON_INPUT" && active.observedTurnEvidence) {
+      if (active.pendingTerminal) return;
       this.completeActiveTurn({
         runtime: active.runtime,
         stopReason: null,
@@ -368,14 +370,19 @@ export class RemoteTurnCoordinator {
     }
     const errorCode = toSdkErrorCode(finished.stopReason);
     const success = !isFailureStopReason(finished.stopReason);
-    this.completeActiveTurn({
+    const terminal = {
       runtime: active.runtime,
       stopReason: finished.stopReason,
       runIds: [...active.runIds],
       success,
       ...(success ? {} : { errorCode: errorCode ?? "error" }),
       ...(finished.error ? { detail: finished.error } : {}),
-    });
+    } satisfies RuntimeTurnResult;
+    if (active.pendingTerminal) {
+      active.pendingTerminal = terminal;
+      return;
+    }
+    this.completeActiveTurn(terminal);
   }
 
   private handleTurnTerminalDelta(
@@ -391,11 +398,18 @@ export class RemoteTurnCoordinator {
         active.observedRequiresApprovalStop = true;
         return;
       }
-      this.completeActiveTurn({
+      // Hosted streams send final usage after stop_reason. Keep result last so
+      // consumers that stop at result cannot miss the accounting event.
+      active.pendingTerminal = {
         runtime: active.runtime,
         stopReason,
         runIds: [...active.runIds],
-      });
+      };
+      return;
+    }
+
+    if (messageType === "usage_statistics" && active.pendingTerminal) {
+      this.completeActiveTurn(active.pendingTerminal);
       return;
     }
 

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -401,6 +401,35 @@ function fakeAppServerHandle(
       }
       stream.serverMessage(message);
     };
+    const emitSuccessfulTerminal = (runId: string) => {
+      emitStream({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+          run_id: runId,
+        },
+      });
+      emitStream({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "usage_statistics",
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+          step_count: 1,
+        },
+      });
+      emitStream({
+        type: "turn_finished",
+        runtime,
+        turn_id: `turn-${runId}`,
+        run_id: runId,
+        stop_reason: "end_turn",
+      });
+    };
 
     if (FakeAppServerSocket.inputScenario === "queuedSecond") {
       const inputCount = control.sent.filter(
@@ -494,15 +523,7 @@ function fakeAppServerHandle(
           run_id: "run-final",
         },
       });
-      emitStream({
-        type: "stream_delta",
-        runtime,
-        delta: {
-          message_type: "stop_reason",
-          stop_reason: "end_turn",
-          run_id: "run-final",
-        },
-      });
+      emitSuccessfulTerminal("run-final");
       return;
     }
 
@@ -539,15 +560,7 @@ function fakeAppServerHandle(
             run_id: "run-final",
           },
         });
-        emitStream({
-          type: "stream_delta",
-          runtime,
-          delta: {
-            message_type: "stop_reason",
-            stop_reason: "end_turn",
-            run_id: "run-final",
-          },
-        });
+        emitSuccessfulTerminal("run-final");
         return;
       }
 
@@ -653,17 +666,8 @@ function fakeAppServerHandle(
         run_id: "run-1",
       },
     };
-    const stopDelta = {
-      type: "stream_delta",
-      runtime,
-      delta: {
-        message_type: "stop_reason",
-        stop_reason: "end_turn",
-        run_id: "run-1",
-      },
-    };
     emitStream(assistantDelta);
-    emitStream(stopDelta);
+    emitSuccessfulTerminal("run-1");
   }
 }
 
@@ -1376,6 +1380,23 @@ describe("LettaAgentClient", () => {
           run_id: "run-first",
         },
       });
+      fakeStreamSocket().serverMessage({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "usage_statistics",
+          total_tokens: 12,
+          step_count: 1,
+        },
+      });
+      fakeStreamSocket().serverMessage({
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first",
+        run_id: "run-first",
+        stop_reason: "end_turn",
+      });
+      firstMessages.push((await firstIterator.next()).value);
       firstMessages.push((await firstIterator.next()).value);
       expect(firstMessages.at(-1)).toMatchObject({
         type: "result",
@@ -1397,6 +1418,22 @@ describe("LettaAgentClient", () => {
           content: "second response",
           run_id: "run-second",
         },
+      });
+      fakeStreamSocket().serverMessage({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "usage_statistics",
+          total_tokens: 12,
+          step_count: 1,
+        },
+      });
+      fakeStreamSocket().serverMessage({
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-second",
+        run_id: "run-second",
+        stop_reason: "end_turn",
       });
       fakeStreamSocket().serverMessage({
         type: "stream_delta",

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -252,6 +252,7 @@ class FakeCloudSocket {
   static instances: FakeCloudSocket[] = [];
   static scenario:
     | "normal"
+    | "usage_after_stop"
     | "approval"
     | "terminal_error"
     | "stale_idle_then_error"
@@ -468,6 +469,11 @@ class FakeCloudSocket {
       return;
     }
 
+    if (payload?.kind === "create_message" && FakeCloudSocket.scenario === "usage_after_stop") {
+      this.finishTurnWithUsageAfterStop(runtime);
+      return;
+    }
+
     if (payload?.kind === "approval_response") {
       this.finishTurn(runtime, "approved");
       return;
@@ -499,6 +505,52 @@ class FakeCloudSocket {
       loop_status: {
         status: "WAITING_ON_INPUT",
         active_run_ids: ["run-cloud"],
+      },
+    });
+  }
+
+  private finishTurnWithUsageAfterStop(runtime: unknown): void {
+    this.serverMessageTo("stream", {
+      type: "stream_delta",
+      seq: 501,
+      event_seq: 1,
+      runtime,
+      delta: {
+        id: "msg-cloud-usage",
+        message_type: "assistant_message",
+        content: "usage captured",
+        run_id: "run-cloud-usage",
+      },
+    });
+    this.serverMessageTo("stream", {
+      type: "stream_delta",
+      seq: 502,
+      event_seq: 2,
+      runtime,
+      delta: {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-cloud-usage",
+      },
+    });
+    this.serverMessageTo("control", {
+      type: "turn_finished",
+      runtime,
+      turn_id: "turn-cloud-usage",
+      run_id: "run-cloud-usage",
+      stop_reason: "end_turn",
+    });
+    this.serverMessageTo("stream", {
+      type: "stream_delta",
+      seq: 503,
+      event_seq: 3,
+      runtime,
+      delta: {
+        message_type: "usage_statistics",
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        step_count: 3,
       },
     });
   }
@@ -622,6 +674,48 @@ function resetFakeCloud(): void {
 }
 
 describe("CloudEnvironmentSession", () => {
+  test("keeps hosted usage after stop ahead of the terminal result", async () => {
+    resetFakeCloud();
+    FakeCloudSocket.scenario = "usage_after_stop";
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      environment: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("agent-1");
+    try {
+      await session.send("hello");
+      const messages = [];
+      for await (const message of session.stream()) messages.push(message);
+
+      expect(messages.map((message) => message.type)).toEqual([
+        "assistant",
+        "stream_event",
+        "result",
+      ]);
+      expect(messages[1]).toMatchObject({
+        type: "stream_event",
+        event: {
+          message_type: "usage_statistics",
+          step_count: 3,
+        },
+      });
+      expect(messages[2]).toMatchObject({
+        type: "result",
+        success: true,
+        runIds: ["run-cloud-usage"],
+      });
+    } finally {
+      session.close();
+    }
+  });
+
   test("creates, refreshes, and cleans up a managed Cloud sandbox with terminateOnClose", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -286,7 +286,28 @@ describe("remote turn terminal receipts", () => {
       }),
       runtime,
     );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-1",
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 1,
+      }),
+      runtime,
+    );
     expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics" },
+    });
     expect(await coordinator.nextMessage()).toMatchObject({
       type: "result",
       runIds: ["run-1"],
@@ -333,6 +354,61 @@ describe("remote turn terminal receipts", () => {
       success: true,
       result: "second",
       runIds: ["run-2"],
+    });
+    coordinator.close();
+  });
+
+  test("keeps trailing usage ahead of the terminal result", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "done",
+        run_id: "run-usage",
+        id: "message-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-usage",
+      }),
+      runtime,
+    );
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        step_count: 3,
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "done",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: {
+        message_type: "usage_statistics",
+        step_count: 3,
+      },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "done",
+      runIds: ["run-usage"],
     });
     coordinator.close();
   });


### PR DESCRIPTION
## Summary
- defer remote terminal results when hosted usage follows `stop_reason`
- prevent `turn_finished` and idle status races from overtaking trailing usage
- cover coordinator, app-server, and Cloud ordering paths

## Validation
- `bun run check`
- `bun test` (268 passed, 12 skipped)
- `bun run build`