### PR TITLE
feat: expose conversation forks

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,3 +51,35 @@ bun examples/sdk-tour.ts basic
 ```
 
 Then read the function that produced the output. Each lesson is a separate function in [`sdk-tour.ts`](./sdk-tour.ts).
+
+## Fork a conversation
+
+A fork copies in-context messages into a new conversation. Omit `messageId` to copy the full history. Set `messageId` to stop after one source message.
+
+```ts
+const fork = await client.conversations.fork(sourceConversationId, {
+  messageId: checkpointMessageId,
+  hidden: true,
+});
+
+try {
+  // The fork has independent history but uses the same agent and memory.
+  await using session = client.resumeSession(fork.id);
+  await session.send('Review the first approach without changing the source.');
+
+  for await (const message of session.stream()) {
+    if (message.type === 'assistant') process.stdout.write(message.content);
+  }
+} finally {
+  // Closing a session does not archive its conversation.
+  await client.conversations.update(fork.id, { archived: true });
+}
+```
+
+Use `update()` before the session if the fork needs a different model:
+
+```ts
+await client.conversations.update(fork.id, {
+  model: 'letta/auto-fast',
+});
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,7 @@ Then read the function that produced the output. Each lesson is a separate funct
 
 ## Fork a conversation
 
-A fork copies in-context messages into a new conversation. Omit `messageId` to copy the full history. Set `messageId` to stop after one source message.
+A fork copies in-context messages into a new conversation. Omit `messageId` to copy the full history. Set `messageId` to stop at that source message, inclusive.
 
 ```ts
 const fork = await client.conversations.fork(sourceConversationId, {

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -10,6 +10,7 @@ import type {
   AgentRetrieveResponseMessage,
   AgentUpdateResponseMessage,
   ConversationCreateResponseMessage,
+  ConversationForkResponseMessage,
   ConversationListResponseMessage,
   ConversationMessagesListResponseMessage,
   ConversationRetrieveResponseMessage,
@@ -22,6 +23,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   ConversationCreateParams,
+  ConversationForkParams,
   ConversationListParams,
   ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
@@ -197,6 +199,23 @@ export class AppServerManagementTransport
       response.conversation,
       `Failed to update conversation ${conversationId}.`,
     );
+  }
+
+  async forkConversation(
+    conversationId: string,
+    body: ConversationForkParams,
+  ): Promise<LettaConversation> {
+    const response = await this.request<ConversationForkResponseMessage>(
+      "conversation_fork",
+      { conversation_id: conversationId, body },
+      "conversation_fork_response",
+    );
+    const fork = ensureResponse(
+      response,
+      response.conversation,
+      `Failed to fork conversation ${conversationId}.`,
+    );
+    return this.retrieveConversation(fork.id);
   }
 
   async listConversationMessages(

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -29,6 +29,7 @@ import type {
 } from "@letta-ai/letta-client/resources/conversations/conversations";
 import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import { normalizeAppServerModels } from "./app-server-models.js";
+import { ConversationForkHydrationError } from "./management-errors.js";
 import type { ManagementTransport } from "./management.js";
 import { applyUniqueRequestIds } from "./request-ids.js";
 import type {
@@ -215,7 +216,11 @@ export class AppServerManagementTransport
       response.conversation,
       `Failed to fork conversation ${conversationId}.`,
     );
-    return this.retrieveConversation(fork.id);
+    try {
+      return await this.retrieveConversation(fork.id);
+    } catch (error) {
+      throw new ConversationForkHydrationError(fork.id, error);
+    }
   }
 
   async listConversationMessages(

--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -24,6 +24,7 @@ export class LettaAgentClient extends LettaAgentClientBase {
 }
 
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
+export { ConversationForkHydrationError } from "./management-errors.js";
 export { RepositoriesClient } from "./repositories.js";
 export type {
   Computer,

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -6,6 +6,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   ConversationCreateParams,
+  ConversationForkParams,
   ConversationListParams,
   ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
@@ -215,6 +216,13 @@ export class CloudManagementTransport implements ManagementTransport {
     body: ConversationUpdateParams,
   ): Promise<LettaConversation> {
     return this.client.conversations.update(conversationId, body);
+  }
+
+  async forkConversation(
+    conversationId: string,
+    query: ConversationForkParams,
+  ): Promise<LettaConversation> {
+    return this.client.conversations.fork(conversationId, query);
   }
 
   async listConversationMessages(

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export type {
   UpdateAgentOptions,
   ListConversationsOptions,
   CreateConversationOptions,
+  ForkConversationOptions,
   UpdateConversationOptions,
   ConversationMessagesOptions,
   ConversationMessagesResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,7 @@ export type {
 } from "./management-types.js";
 
 export { RepositoriesClient } from "./repositories.js";
+export { ConversationForkHydrationError } from "./management-errors.js";
 export type {
   Computer,
   ComputerMetadata,

--- a/src/management-errors.ts
+++ b/src/management-errors.ts
@@ -1,0 +1,16 @@
+/**
+ * The App Server created a fork but the SDK could not retrieve its full state.
+ * `conversationId` remains available so the caller can inspect or archive it.
+ */
+export class ConversationForkHydrationError extends Error {
+  readonly conversationId: string;
+
+  constructor(conversationId: string, cause: unknown) {
+    super(
+      `Conversation ${conversationId} was forked, but its state could not be retrieved.`,
+      { cause },
+    );
+    this.name = "ConversationForkHydrationError";
+    this.conversationId = conversationId;
+  }
+}

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -182,7 +182,8 @@ export interface ConversationsClient {
   ): Promise<LettaConversation>;
   /**
    * Create a persistent conversation from the source's in-context history.
-   * Use `update(fork.id, { archived: true })` when a temporary fork is done.
+   * Use `update()` to change the fork's model. Archive a temporary fork with
+   * `update(fork.id, { archived: true })` when it is done.
    */
   fork(
     sourceConversationId: string,

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -7,6 +7,7 @@ import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import type {
   Conversation,
   ConversationCreateParams,
+  ConversationForkParams,
   ConversationListParams,
   ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
@@ -78,6 +79,13 @@ export interface UpdateConversationOptions {
   modelSettings?: ConversationUpdateParams["model_settings"];
   contextWindowLimit?: ConversationUpdateParams["context_window_limit"];
   archived?: ConversationUpdateParams["archived"];
+}
+
+export interface ForkConversationOptions {
+  /** Include source messages through this message, inclusive. */
+  messageId?: Present<ConversationForkParams["message_id"]>;
+  /** Hide the fork from normal conversation listings. */
+  hidden?: Present<ConversationForkParams["hidden"]>;
 }
 
 export interface ConversationMessagesOptions {
@@ -171,6 +179,14 @@ export interface ConversationsClient {
   update(
     conversationId: string,
     options: UpdateConversationOptions,
+  ): Promise<LettaConversation>;
+  /**
+   * Create a persistent conversation from the source's in-context history.
+   * Use `update(fork.id, { archived: true })` when a temporary fork is done.
+   */
+  fork(
+    sourceConversationId: string,
+    options?: ForkConversationOptions,
   ): Promise<LettaConversation>;
   listMessages(
     conversationId: string,

--- a/src/management.ts
+++ b/src/management.ts
@@ -4,6 +4,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   ConversationCreateParams,
+  ConversationForkParams,
   ConversationListParams,
   ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
@@ -14,6 +15,7 @@ import type {
   ConversationsClient,
   ConversationMessagesResult,
   CreateConversationOptions,
+  ForkConversationOptions,
   LettaAgent,
   LettaConversation,
   ListAgentsOptions,
@@ -46,6 +48,10 @@ export interface ManagementTransport {
   updateConversation(
     conversationId: string,
     body: ConversationUpdateParams,
+  ): Promise<LettaConversation>;
+  forkConversation(
+    conversationId: string,
+    query: ConversationForkParams,
   ): Promise<LettaConversation>;
   listConversationMessages(
     conversationId: string,
@@ -143,6 +149,15 @@ function conversationUpdateBody(
   };
 }
 
+function conversationForkQuery(
+  options: ForkConversationOptions,
+): ConversationForkParams {
+  return {
+    message_id: options.messageId,
+    hidden: options.hidden,
+  };
+}
+
 function conversationMessagesQuery(
   options: ConversationMessagesOptions,
 ): MessageListParams {
@@ -197,6 +212,13 @@ export function createConversationsClient(
         conversationId,
         conversationUpdateBody(options),
       ),
+    fork: async (sourceConversationId, options = {}) => {
+      assertNonEmptyId(sourceConversationId, "conversation id");
+      return await transport().forkConversation(
+        sourceConversationId,
+        conversationForkQuery(options),
+      );
+    },
     listMessages: (conversationId, options = {}) =>
       transport().listConversationMessages(
         conversationId,

--- a/src/management.ts
+++ b/src/management.ts
@@ -214,6 +214,9 @@ export function createConversationsClient(
       ),
     fork: async (sourceConversationId, options = {}) => {
       assertNonEmptyId(sourceConversationId, "conversation id");
+      if (options.messageId !== undefined) {
+        assertNonEmptyId(options.messageId, "message id");
+      }
       return await transport().forkConversation(
         sourceConversationId,
         conversationForkQuery(options),

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -18,6 +18,7 @@ const RECORD_FIXTURES = process.env.LETTA_RECORD_FIXTURES === "1";
 const BASE_URL = process.env.LETTA_BASE_URL ?? "https://api.letta.com";
 const AGENT_ID_OVERRIDE = process.env.LETTA_AGENT_ID;
 const CONVERSATION_ID_OVERRIDE = process.env.LETTA_CONVERSATION_ID;
+const COMPUTER_ID_OVERRIDE = process.env.LETTA_LIVE_COMPUTER_ID;
 const TEST_TIMEOUT_MS = Number(process.env.LETTA_LIVE_TEST_TIMEOUT_MS ?? "180000");
 
 const describeLive = RUN_LIVE ? describe : describe.skip;
@@ -567,10 +568,14 @@ describeLive("live integration: letta-agent-sdk", () => {
         backend: "cloud",
         apiKey: API_KEY,
         apiBaseUrl: BASE_URL,
+        ...(COMPUTER_ID_OVERRIDE
+          ? { computer: { id: COMPUTER_ID_OVERRIDE } }
+          : {}),
       });
       const nonce = Math.random().toString(36).slice(2, 10);
       const firstMarker = `FORK_FIRST_${nonce}`;
       const secondMarker = `FORK_SECOND_${nonce}`;
+      const forkLaneMarker = `FORK_LANE_${nonce}`;
       const activeConversationIds: string[] = [];
 
       const sendMessage = async (
@@ -656,6 +661,27 @@ describeLive("live integration: letta-agent-sdk", () => {
         expect(fullText).toContain(secondMarker);
         expect(checkpointText).toContain(firstMarker);
         expect(checkpointText).not.toContain(secondMarker);
+
+        await using forkSession = management.resumeSession(checkpointFork.id, {
+          permissionMode: "unrestricted",
+        });
+        const forkTurn = await collectTurn(
+          forkSession,
+          `${forkLaneMarker}: Reply with exactly the earlier FORK_FIRST marker and nothing else.`,
+        );
+        const forkResult = expectTerminalResult(forkTurn);
+        expect(forkResult.success).toBe(true);
+        expect(forkResult.result).toContain(firstMarker);
+        expect(forkResult.result).not.toContain(secondMarker);
+
+        const sourceAfterForkTurn =
+          await management.conversations.listMessages(source.id, {
+            order: "asc",
+            limit: 100,
+          });
+        expect(JSON.stringify(sourceAfterForkTurn.messages)).not.toContain(
+          forkLaneMarker,
+        );
 
         for (const conversationId of activeConversationIds) {
           const archived = await management.conversations.update(

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -614,9 +614,13 @@ describeLive("live integration: letta-agent-sdk", () => {
             order: "asc",
             limit: 100,
           });
-        const checkpoint = firstHistory.messages.find((message) =>
-          JSON.stringify(message).includes(firstMarker)
-        )?.id;
+        const checkpointMessage = firstHistory.messages.find(
+          (message) =>
+            message.message_type === "assistant_message" &&
+            JSON.stringify(message).includes(firstMarker),
+        );
+        expect(checkpointMessage?.message_type).toBe("assistant_message");
+        const checkpoint = checkpointMessage?.id;
         expect(checkpoint).toBeDefined();
 
         await sendMessage(source.id, secondMarker);

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -558,6 +558,121 @@ describeLive("live integration: letta-agent-sdk", () => {
   );
 
   test(
+    "conversation forks preserve full or checkpointed history and can be archived",
+    async () => {
+      await ensureAgentReady();
+      if (!API_KEY) throw new Error("LETTA_API_KEY is required");
+
+      const management = new LettaAgentClient({
+        backend: "cloud",
+        apiKey: API_KEY,
+        apiBaseUrl: BASE_URL,
+      });
+      const nonce = Math.random().toString(36).slice(2, 10);
+      const firstMarker = `FORK_FIRST_${nonce}`;
+      const secondMarker = `FORK_SECOND_${nonce}`;
+      const activeConversationIds: string[] = [];
+
+      const sendMessage = async (
+        conversationId: string,
+        marker: string,
+      ): Promise<void> => {
+        const response = await fetch(
+          `${BASE_URL}/v1/conversations/${conversationId}/messages`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${API_KEY}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              input: `Reply with exactly this text and nothing else: ${marker}`,
+              streaming: false,
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(
+            `Failed to seed fork history: ${response.status} ${await response.text()}`,
+          );
+        }
+      };
+
+      try {
+        const source = await management.conversations.create({
+          agentId,
+          summary: `SDK fork source ${nonce}`,
+          model: "letta/auto-fast",
+          hidden: true,
+        });
+        activeConversationIds.push(source.id);
+
+        await sendMessage(source.id, firstMarker);
+
+        const firstHistory =
+          await management.conversations.listMessages(source.id, {
+            order: "asc",
+            limit: 100,
+          });
+        const checkpoint = firstHistory.messages.find((message) =>
+          JSON.stringify(message).includes(firstMarker)
+        )?.id;
+        expect(checkpoint).toBeDefined();
+
+        await sendMessage(source.id, secondMarker);
+
+        const fullFork = await management.conversations.fork(
+          source.id,
+          { hidden: true },
+        );
+        activeConversationIds.push(fullFork.id);
+        const checkpointFork = await management.conversations.fork(
+          source.id,
+          {
+            messageId: checkpoint!,
+            hidden: true,
+          },
+        );
+        activeConversationIds.push(checkpointFork.id);
+
+        const fullHistory =
+          await management.conversations.listMessages(fullFork.id, {
+            order: "asc",
+            limit: 100,
+          });
+        const checkpointHistory =
+          await management.conversations.listMessages(checkpointFork.id, {
+            order: "asc",
+            limit: 100,
+          });
+        const fullText = JSON.stringify(fullHistory.messages);
+        const checkpointText = JSON.stringify(checkpointHistory.messages);
+
+        expect(fullText).toContain(firstMarker);
+        expect(fullText).toContain(secondMarker);
+        expect(checkpointText).toContain(firstMarker);
+        expect(checkpointText).not.toContain(secondMarker);
+
+        for (const conversationId of activeConversationIds) {
+          const archived = await management.conversations.update(
+            conversationId,
+            { archived: true },
+          );
+          expect(archived.archived).toBe(true);
+        }
+        activeConversationIds.length = 0;
+      } finally {
+        for (const conversationId of activeConversationIds) {
+          await management.conversations.update(conversationId, {
+            archived: true,
+          });
+        }
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
     "listMessages is safe while stream is active",
     async () => {
       await ensureAgentReady();

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -121,6 +121,26 @@ function createManagementFetch(
     ) {
       return jsonResponse([USER_MESSAGE_FIXTURE]);
     }
+    if (
+      url.pathname === "/v1/conversations/conv-source/fork" &&
+      method === "POST"
+    ) {
+      return jsonResponse({
+        id: "conv-fork",
+        agent_id: "agent-1",
+        archived: false,
+      });
+    }
+    if (
+      url.pathname === "/v1/conversations/conv-fork" &&
+      method === "PATCH"
+    ) {
+      return jsonResponse({
+        id: "conv-fork",
+        agent_id: "agent-1",
+        archived: true,
+      });
+    }
     return jsonResponse({ detail: "not found" }, { status: 404 });
   }) as typeof fetch;
 }
@@ -218,6 +238,11 @@ class ManagementSocket {
           id: command.conversation_id,
           agent_id: "agent-1",
           ...(command.body as object),
+        },
+      },
+      conversation_fork: {
+        conversation: {
+          id: "conv-fork",
         },
       },
       conversation_messages_list: {
@@ -320,6 +345,181 @@ async function exerciseManagementApi(
 }
 
 describe("portable management namespaces", () => {
+  test("forks through a selected message and archives the fork over Cloud", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    const fork = await client.conversations.fork("conv-source", {
+      messageId: "message-checkpoint",
+      hidden: true,
+    });
+    expect(fork).toMatchObject({
+      id: "conv-fork",
+      agent_id: "agent-1",
+      archived: false,
+    });
+
+    await expect(
+      client.conversations.update(fork.id, { archived: true }),
+    ).resolves.toMatchObject({
+      id: "conv-fork",
+      archived: true,
+    });
+
+    expect(
+      requests.map(({ url, method, body }) => ({
+        path: url.pathname,
+        query: Object.fromEntries(url.searchParams),
+        method,
+        body,
+      })),
+    ).toEqual([
+      {
+        path: "/v1/conversations/conv-source/fork",
+        query: {
+          hidden: "true",
+          message_id: "message-checkpoint",
+        },
+        method: "POST",
+        body: undefined,
+      },
+      {
+        path: "/v1/conversations/conv-fork",
+        query: {},
+        method: "PATCH",
+        body: { archived: true },
+      },
+    ]);
+  });
+
+  test("omits fork query parameters when copying the full history", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    await expect(
+      client.conversations.fork("conv-source"),
+    ).resolves.toMatchObject({ id: "conv-fork" });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.pathname).toBe(
+      "/v1/conversations/conv-source/fork",
+    );
+    expect(Object.fromEntries(requests[0]!.url.searchParams)).toEqual({});
+    expect(requests[0]?.body).toBeUndefined();
+  });
+
+  test("rejects an empty fork source before selecting a transport", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    await expect(
+      client.conversations.fork("  ", { hidden: true }),
+    ).rejects.toThrow(
+      "Invalid conversation id. Expected a non-empty string.",
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  test("forks and archives through the App Server protocol", async () => {
+    ManagementSocket.instances = [];
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      WebSocket: ManagementSocket,
+    });
+
+    const fork = await client.conversations.fork("conv-source", {
+      messageId: "message-checkpoint",
+      hidden: true,
+    });
+    expect(fork).toMatchObject({
+      id: "conv-fork",
+      agent_id: "agent-1",
+    });
+
+    await expect(
+      client.conversations.update(fork.id, { archived: true }),
+    ).resolves.toMatchObject({ id: "conv-fork", archived: true });
+
+    const commands = ManagementSocket.instances.flatMap(
+      (socket) => socket.sent,
+    );
+    expect(commands).toEqual([
+      expect.objectContaining({
+        type: "conversation_fork",
+        conversation_id: "conv-source",
+        body: {
+          message_id: "message-checkpoint",
+          hidden: true,
+        },
+      }),
+      expect.objectContaining({
+        type: "conversation_retrieve",
+        conversation_id: "conv-fork",
+      }),
+      expect.objectContaining({
+        type: "conversation_update",
+        conversation_id: "conv-fork",
+        body: { archived: true },
+      }),
+    ]);
+  });
+
+  test("does not retrieve a conversation after an App Server fork failure", async () => {
+    class FailingForkSocket extends ManagementSocket {
+      protected override respond(command: Record<string, unknown>): void {
+        queueMicrotask(() => {
+          this.emit("message", {
+            data: JSON.stringify({
+              type: "conversation_fork_response",
+              request_id: command.request_id,
+              success: false,
+              conversation: null,
+              error: "Source message was not found.",
+            }),
+          });
+        });
+      }
+    }
+
+    ManagementSocket.instances = [];
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      WebSocket: FailingForkSocket,
+    });
+
+    await expect(
+      client.conversations.fork("conv-source", {
+        messageId: "message-missing",
+      }),
+    ).rejects.toThrow("Source message was not found.");
+
+    const commands = ManagementSocket.instances.flatMap(
+      (socket) => socket.sent,
+    );
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({
+      type: "conversation_fork",
+      conversation_id: "conv-source",
+    });
+  });
+
   test("map the portable API to Cloud REST", async () => {
     const requests: RecordedRequest[] = [];
     const client = new PortableLettaAgentClient({

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -3,7 +3,10 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { AppServerManagementTransport } from "../app-server-management.js";
 import { LettaAgentClient as PortableLettaAgentClient } from "../client-entry.js";
-import { LettaAgentClient as NodeLettaAgentClient } from "../index.js";
+import {
+  ConversationForkHydrationError,
+  LettaAgentClient as NodeLettaAgentClient,
+} from "../index.js";
 import type { LettaCodeSocketOptions } from "../types.js";
 import { asAdvanced } from "./advanced-session.js";
 
@@ -435,6 +438,23 @@ describe("portable management namespaces", () => {
     expect(requests).toHaveLength(0);
   });
 
+  test("rejects an empty fork checkpoint before selecting a transport", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    await expect(
+      client.conversations.fork("conv-source", { messageId: "" }),
+    ).rejects.toThrow(
+      "Invalid message id. Expected a non-empty string.",
+    );
+    expect(requests).toHaveLength(0);
+  });
+
   test("forks and archives through the App Server protocol", async () => {
     ManagementSocket.instances = [];
     const client = new PortableLettaAgentClient({
@@ -518,6 +538,52 @@ describe("portable management namespaces", () => {
       type: "conversation_fork",
       conversation_id: "conv-source",
     });
+  });
+
+  test("preserves the fork id when App Server hydration fails", async () => {
+    class FailingForkHydrationSocket extends ManagementSocket {
+      protected override respond(command: Record<string, unknown>): void {
+        const type = String(command.type);
+        queueMicrotask(() => {
+          this.emit("message", {
+            data: JSON.stringify(
+              type === "conversation_fork"
+                ? {
+                    type: "conversation_fork_response",
+                    request_id: command.request_id,
+                    success: true,
+                    conversation: { id: "conv-orphan" },
+                  }
+                : {
+                    type: "conversation_retrieve_response",
+                    request_id: command.request_id,
+                    success: false,
+                    conversation: null,
+                    error: "Connection closed during hydration.",
+                  },
+            ),
+          });
+        });
+      }
+    }
+
+    ManagementSocket.instances = [];
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      WebSocket: FailingForkHydrationSocket,
+    });
+
+    try {
+      await client.conversations.fork("conv-source");
+      throw new Error("Expected fork hydration to fail.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConversationForkHydrationError);
+      expect((error as ConversationForkHydrationError).conversationId).toBe(
+        "conv-orphan",
+      );
+      expect((error as Error).message).toContain("conv-orphan");
+    }
   });
 
   test("map the portable API to Cloud REST", async () => {


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## What changed

- Add `conversations.fork(sourceConversationId, options)` to the Node and `/client` entries.
- Map `messageId` to the Cloud `message_id` query parameter.
- Use the existing App Server `conversation_fork` command, then retrieve the full conversation.
- Keep cleanup on `conversations.update(id, { archived: true })`.

Closes #288.

## Behavior

A fork copies the source conversation's full in-context history by default. Set `messageId` to copy history through one message. Forks persist until the caller archives them.

## Validation

- Test-first check: 5 focused management tests failed before implementation because `fork()` was absent.
- `bun run check`
- `bun test` — 270 passed, 13 live tests skipped
- `bun run build`
- Live Cloud acceptance — 1 passed. It verified full-history copying, checkpoint copying, and archival for the source and both forks.
