### PR TITLE
fix: document session model scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
           LETTA_LIVE_INTEGRATION: "1"
-        run: bun test src/tests/live.integration.test.ts -t "createSession model override changes only the new conversation"
+        run: bun test src/tests/live.integration.test.ts -t "session model scope"
 
       - name: Cloud transport disconnect integration test
         # Only run with API key on push or same-repo PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
         run: bun examples/sdk-tour.ts all
 
+      - name: Session model scope integration test
+        # Only run with API key on push or same-repo PRs
+        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        env:
+          LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+          LETTA_LIVE_INTEGRATION: "1"
+        run: bun test src/tests/live.integration.test.ts -t "createSession model override changes only the new conversation"
+
       - name: Cloud transport disconnect integration test
         # Only run with API key on push or same-repo PRs
         if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -327,7 +327,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   async updateModel(update: string | UpdateModelOptions): Promise<UpdateModelResult> {
     if (this.mode.kind === "session" && this.mode.options.stateless === true) {
       throw new Error(
-        "updateModel() is unavailable in a stateless session because it changes persisted agent configuration.",
+        "updateModel() is unavailable in a stateless session because it changes persistent model configuration.",
       );
     }
     if (!this.initialized) {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -232,6 +232,9 @@ function fakeAppServerHandle(
 
   if (command.type === "update_model") {
     const payload = command.payload as Record<string, unknown> | undefined;
+    const runtime = command.runtime as
+      | { conversation_id?: string }
+      | undefined;
     const byId = FAKE_MODEL_ENTRIES.find((entry) => entry.id === payload?.model_id);
     const byHandle = FAKE_MODEL_ENTRIES.find((entry) => entry.handle === payload?.model_handle);
     const modelHandle =
@@ -242,7 +245,8 @@ function fakeAppServerHandle(
       request_id: command.request_id,
       success: true,
       runtime: command.runtime,
-      applied_to: "conversation",
+      applied_to:
+        runtime?.conversation_id === "default" ? "agent" : "conversation",
       model_id:
         (typeof payload?.model_id === "string" ? payload.model_id : undefined) ??
         byHandle?.id,
@@ -2504,7 +2508,7 @@ describe("LettaAgentClient", () => {
     }
   });
 
-  test("websocket protocol sessions list models, apply reasoning effort, and abort", async () => {
+  test("default conversation model updates apply to the agent", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -2550,7 +2554,7 @@ describe("LettaAgentClient", () => {
         reasoningEffort: "low",
       });
       expect(updateResult).toMatchObject({
-        appliedTo: "conversation",
+        appliedTo: "agent",
         modelId: "sonnet-low",
         modelHandle: "anthropic/claude-sonnet-4",
       });
@@ -2563,6 +2567,41 @@ describe("LettaAgentClient", () => {
       expect(fakeControlSocket().sent.at(-1)).toMatchObject({
         type: "abort_message",
         runtime: { agent_id: "agent-123", conversation_id: "default" },
+      });
+    } finally {
+      session.close();
+    }
+  });
+
+  test("new conversation model updates apply only to the conversation", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+    const session = client.createSession("agent-123", {
+      model: "anthropic/claude-opus-4",
+    });
+
+    try {
+      await asAdvanced(session).initialize();
+
+      expect(fakeControlSocket().sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "update_model",
+            runtime: {
+              agent_id: "agent-123",
+              conversation_id: "conv-created",
+            },
+          }),
+        ]),
+      );
+      const updateResult = await session.updateModel("anthropic/claude-sonnet-4");
+      expect(updateResult).toMatchObject({
+        appliedTo: "conversation",
+        modelHandle: "anthropic/claude-sonnet-4",
       });
     } finally {
       session.close();

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -417,7 +417,7 @@ describeLive("live integration: letta-agent-sdk", () => {
   );
 
   test(
-    "createSession model override changes only the new conversation",
+    "session model scope: createSession changes only the new conversation",
     async () => {
       const client = new LettaAgentClient({
         backend: "cloud",
@@ -459,6 +459,54 @@ describeLive("live integration: letta-agent-sdk", () => {
           await client.agents.delete(testAgentId);
         } else if (conversationId) {
           await client.conversations.update(conversationId, { archived: true });
+        }
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "session model scope: resumeSession(agentId) changes the agent default",
+    async () => {
+      const client = new LettaAgentClient({
+        backend: "cloud",
+        apiKey: API_KEY!,
+        apiBaseUrl: BASE_URL,
+      });
+      const availableAgents = await client.agents.list({ limit: 100 });
+      const reusableAgent =
+        availableAgents.find((agent) =>
+          agent.name?.startsWith("sdk-model-scope-test-"),
+        ) ?? availableAgents[0];
+      const testAgentId = reusableAgent?.id ?? await client.createAgent({
+        name: `sdk-model-scope-test-${Date.now()}`,
+        model: "letta/auto",
+        tags: ["sdk-live-test"],
+        memfs: false,
+      });
+      const createdAgent = reusableAgent === undefined;
+      const agentBefore = await client.agents.retrieve(testAgentId);
+      let session: LettaCodeSession | undefined;
+
+      try {
+        session = client.resumeSession(testAgentId, {
+          model: "letta/auto-fast",
+          permissionMode: "unrestricted",
+        });
+        openedSessions.push(session);
+
+        const state = await session.bootstrapState({ limit: 1 });
+        const agentAfter = await client.agents.retrieve(testAgentId);
+
+        expect(state.conversationId).toBe("default");
+        expect(state.model).toBe("letta/auto-fast");
+        expect(agentAfter.model).toBe("letta/auto-fast");
+      } finally {
+        session?.close();
+        if (createdAgent) {
+          await client.agents.delete(testAgentId);
+        } else if (agentBefore.model) {
+          await client.agents.update(testAgentId, { model: agentBefore.model });
         }
       }
     },

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -433,6 +433,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       });
       const createdAgent = existingAgent === undefined;
       let session: LettaCodeSession | undefined;
+      let conversationId = "";
 
       try {
         const agentBefore = await client.agents.retrieve(testAgentId);
@@ -443,8 +444,9 @@ describeLive("live integration: letta-agent-sdk", () => {
         openedSessions.push(session);
 
         const state = await session.bootstrapState({ limit: 1 });
+        conversationId = state.conversationId;
         const conversation = await client.conversations.retrieve(
-          state.conversationId,
+          conversationId,
         );
         const agentAfter = await client.agents.retrieve(testAgentId);
 
@@ -455,6 +457,8 @@ describeLive("live integration: letta-agent-sdk", () => {
         session?.close();
         if (createdAgent) {
           await client.agents.delete(testAgentId);
+        } else if (conversationId) {
+          await client.conversations.update(conversationId, { archived: true });
         }
       }
     },

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -417,6 +417,43 @@ describeLive("live integration: letta-agent-sdk", () => {
   );
 
   test(
+    "createSession model override changes only the new conversation",
+    async () => {
+      await ensureAgentReady();
+
+      const client = new LettaAgentClient({
+        backend: "cloud",
+        apiKey: API_KEY!,
+        apiBaseUrl: BASE_URL,
+      });
+      const agentBefore = await client.agents.retrieve(agentId);
+      const session = client.createSession(agentId, {
+        model: "letta/auto-fast",
+        permissionMode: "unrestricted",
+      });
+      openedSessions.push(session);
+
+      let conversationId = "";
+      try {
+        const state = await session.bootstrapState({ limit: 1 });
+        conversationId = state.conversationId;
+        const conversation = await client.conversations.retrieve(conversationId);
+        const agentAfter = await client.agents.retrieve(agentId);
+
+        expect(state.model).toBe("letta/auto-fast");
+        expect(conversation.model).toBe("letta/auto-fast");
+        expect(agentAfter.model).toBe(agentBefore.model);
+      } finally {
+        session.close();
+        if (conversationId) {
+          await client.conversations.update(conversationId, { archived: true });
+        }
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
     "send + stream yields renderable messages and terminal result",
     async () => {
       await ensureAgentReady();

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -419,34 +419,42 @@ describeLive("live integration: letta-agent-sdk", () => {
   test(
     "createSession model override changes only the new conversation",
     async () => {
-      await ensureAgentReady();
-
       const client = new LettaAgentClient({
         backend: "cloud",
         apiKey: API_KEY!,
         apiBaseUrl: BASE_URL,
       });
-      const agentBefore = await client.agents.retrieve(agentId);
-      const session = client.createSession(agentId, {
-        model: "letta/auto-fast",
-        permissionMode: "unrestricted",
+      const existingAgent = (await client.agents.list({ limit: 1 }))[0];
+      const testAgentId = existingAgent?.id ?? await client.createAgent({
+        name: `sdk-model-scope-test-${Date.now()}`,
+        model: "letta/auto",
+        tags: ["sdk-live-test"],
+        memfs: false,
       });
-      openedSessions.push(session);
+      const createdAgent = existingAgent === undefined;
+      let session: LettaCodeSession | undefined;
 
-      let conversationId = "";
       try {
+        const agentBefore = await client.agents.retrieve(testAgentId);
+        session = client.createSession(testAgentId, {
+          model: "letta/auto-fast",
+          permissionMode: "unrestricted",
+        });
+        openedSessions.push(session);
+
         const state = await session.bootstrapState({ limit: 1 });
-        conversationId = state.conversationId;
-        const conversation = await client.conversations.retrieve(conversationId);
-        const agentAfter = await client.agents.retrieve(agentId);
+        const conversation = await client.conversations.retrieve(
+          state.conversationId,
+        );
+        const agentAfter = await client.agents.retrieve(testAgentId);
 
         expect(state.model).toBe("letta/auto-fast");
         expect(conversation.model).toBe("letta/auto-fast");
         expect(agentAfter.model).toBe(agentBefore.model);
       } finally {
-        session.close();
-        if (conversationId) {
-          await client.conversations.update(conversationId, { archived: true });
+        session?.close();
+        if (createdAgent) {
+          await client.agents.delete(testAgentId);
         }
       }
     },

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -62,7 +62,7 @@ describe("validation", () => {
       { stateless: true, resources: [] },
     ]) {
       expect(() => validateCreateSessionOptions(options as never)).toThrow(
-        "changes persisted agent configuration",
+        "changes persistent configuration",
       );
     }
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,6 +611,7 @@ export interface UpdateModelOptions {
 }
 
 export interface UpdateModelResult {
+  /** The scope changed by the runtime. The default conversation uses the agent scope. */
   appliedTo?: "agent" | "conversation";
   modelId?: string;
   modelHandle?: string;
@@ -655,10 +656,16 @@ export interface ClientToolsetConfig {
  * For creating new agents with custom memory/persona, use createAgent().
  */
 export interface CreateSessionOptions {
-  /** Model to use (e.g., "claude-sonnet-4-20250514") - updates the agent's LLM config */
+  /**
+   * Model for the session target. New and named conversations receive a
+   * conversation override. The default conversation updates the agent default.
+   */
   model?: string;
 
-  /** Reasoning effort tier to use with the selected/current model on websocket protocol sessions. */
+  /**
+   * Reasoning tier for the session target. This option uses the same scope as
+   * `model` and is available on WebSocket protocol sessions.
+   */
   reasoningEffort?: ReasoningEffort;
 
   /**
@@ -686,6 +693,8 @@ export interface CreateSessionOptions {
    * Run without loading or changing the agent's MemFS. The agent and
    * conversation remain persistent; this only changes the session's local
    * memory, agent-skill, agent-mod, transcript, and reflection behavior.
+   * Model, reasoning, dreaming, and repository options are unavailable because
+   * they change persistent configuration.
    */
   stateless?: boolean;
 
@@ -770,6 +779,11 @@ export interface LettaCodeSession extends AsyncDisposable {
   ): Promise<TResponse>;
   listMessages(options?: ListMessagesOptions): Promise<ListMessagesResult>;
   listModels(): Promise<ListModelsResult>;
+  /**
+   * Update the model for this session target. Named conversations receive a
+   * conversation override. The default conversation updates the agent default.
+   * Read `appliedTo` from the result to confirm the changed scope.
+   */
   updateModel(update: string | UpdateModelOptions): Promise<UpdateModelResult>;
   /**
    * Fetch the initial conversation projection used to hydrate or reconcile a

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -235,7 +235,7 @@ export function validateCreateSessionOptions(options: CreateSessionOptions): voi
     ].find(([, value]) => value !== undefined);
     if (persistedOption) {
       throw new Error(
-        `stateless sessions cannot set ${persistedOption[0]} because it changes persisted agent configuration.`,
+        `stateless sessions cannot set ${persistedOption[0]} because it changes persistent configuration.`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- Document model scope for session options and `updateModel()`.
- Report `agent` scope for the default conversation and `conversation` scope for new or named conversations.
- Replace the incorrect stateless-session claim about agent-only mutation.
- Add unit and Cloud integration coverage for both scopes.

## Behavior

`createSession(agentId, { model })` applies a conversation override. `resumeSession(conversationId, { model })` uses the same scope. `resumeSession(agentId, { model })` targets the default conversation and updates the agent default.

Stateless sessions still reject persistent model changes. This PR changes the explanation, not that restriction.

## Validation

- `bun run check`
- `bun test` — 275 passed, 15 live tests skipped
- `bun run build`
- `LETTA_LIVE_INTEGRATION=1 bun test src/tests/live.integration.test.ts -t "session model scope"` — 2 passed against Letta Cloud

CI runs both Cloud model-scope tests for same-repository pull requests. One test proves that `createSession()` changes only the new conversation. The other proves that `resumeSession(agentId)` changes the agent default. The tests remove created agents, archive added conversations, and restore reused agent defaults.

Closes #295

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)
