### PR TITLE
feat: expose explicit session readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ for await (const message of session.stream()) {
 }
 ```
 
+Latency-sensitive applications can initialize the runtime and transport before
+the first user action without fetching transcript history or invoking the model:
+
+```typescript
+const session = client.resumeSession(conversationId);
+await session.ready();
+await session.send(message);
+```
+
+`ready()` is idempotent and safe to call concurrently. `SDKResultMessage.durationMs`
+measures the tracked turn and excludes session initialization; measure `ready()`
+separately when startup latency matters.
+
 Set `LETTA_API_KEY` for the cloud backend. See the [quickstart](https://docs.letta.com/agent-sdk/quickstart) for the local and self-hosted paths.
 
 ## Where your agents run

--- a/scripts/check-source-size.ts
+++ b/scripts/check-source-size.ts
@@ -8,7 +8,8 @@ const DEFAULT_LIMIT = 900;
 const FILE_LIMITS: Record<string, number> = {
   "app-server-session.ts": 950,
   "cloud-session.ts": 1_350,
-  "types.ts": 1_350,
+  "remote-client-session-core.ts": 917,
+  "types.ts": 1_351,
 };
 
 const sourceDir = join(import.meta.dir, "..", "src");

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -345,6 +345,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
     await this.mcpCleanup;
+    if (!this.closed) this.sandboxLifecycleClosing = false;
     const resolved = await this.resolveRuntime();
     const connection = await this.resolveConnectionForRuntime(resolved.runtime).catch(
       async (error: unknown) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export type {
   GetDeviceStatusOptions,
   SessionDeviceStatus,
   SessionPendingControlRequest,
+  SessionReadyInfo,
   SessionPermissionSuggestion,
   SessionDiffHunkLine,
   SessionDiffHunk,

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -21,6 +21,7 @@ import type {
   SendCommandOptions,
   SendMessage,
   SendOptions,
+  SessionReadyInfo,
   SessionDeviceStatus,
   UpdateModelOptions,
   UpdateModelResult,
@@ -141,6 +142,22 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
       });
     this.initializePromise = memo;
     return memo;
+  }
+
+  async ready(): Promise<SessionReadyInfo> {
+    if (this.closed) throw new Error("Session is closed");
+    if (!this.initialized) await this.initialize();
+    await this.recoverIdleTransportIfNeeded();
+
+    if (!this._agentId || !this._conversationId) {
+      throw new Error("Session is not initialized");
+    }
+    return {
+      agentId: this._agentId,
+      conversationId: this._conversationId,
+      model: this._model || undefined,
+      ...(this.toolNames !== undefined ? { tools: [...this.toolNames] } : {}),
+    };
   }
 
   private async performInitialize(): Promise<SDKInitMessage> {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1887,7 +1887,7 @@ describe("LettaAgentClient", () => {
     }
   });
 
-  test("concurrent initialize callers resolve from the same attempt", async () => {
+  test("ready is idempotent and concurrent callers share one initialization", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1898,17 +1898,20 @@ describe("LettaAgentClient", () => {
     const session = client.resumeSession("conv-abc");
     try {
       const [first, second] = await Promise.all([
-        asAdvanced(session).initialize(),
-        asAdvanced(session).initialize(),
+        session.ready(),
+        session.ready(),
       ]);
       expect(first).toEqual(second);
       expect(first.conversationId).toBe("conv-abc");
       expect(FakeAppServerSocket.instances).toHaveLength(
         expectedAppServerSocketCount(),
       );
-      await expect(asAdvanced(session).initialize()).rejects.toThrow(
-        "Session already initialized",
-      );
+      expect(await session.ready()).toEqual(first);
+      await session.send("hello");
+      const sent = fakeControlSocket().sent as Array<{ type?: string }>;
+      expect(sent.filter((cmd) => cmd.type === "conversation_retrieve")).toHaveLength(1);
+      expect(sent.filter((cmd) => cmd.type === "runtime_start")).toHaveLength(1);
+      expect(sent.filter((cmd) => cmd.type === "conversation_messages_list")).toHaveLength(0);
     } finally {
       session.close();
     }
@@ -1954,7 +1957,7 @@ describe("LettaAgentClient", () => {
     }
   });
 
-  test("failed post-initialize work clears partial session metadata", async () => {
+  test("ready can retry after failed post-initialize work", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.failNextReflectionSettings = true;
     const client = new LettaAgentClient({
@@ -1967,14 +1970,14 @@ describe("LettaAgentClient", () => {
       dreaming: { trigger: "step-count", stepCount: 3 },
     });
     try {
-      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+      await expect(session.ready()).rejects.toThrow(
         "reflection settings failed (fake)",
       );
       expect(session.agentId).toBeNull();
       expect(session.sessionId).toBeNull();
       expect(session.conversationId).toBeNull();
 
-      const init = await asAdvanced(session).initialize();
+      const init = await session.ready();
       expect(init.agentId).toBe("agent-123");
     } finally {
       FakeAppServerSocket.failNextReflectionSettings = false;
@@ -1982,7 +1985,7 @@ describe("LettaAgentClient", () => {
     }
   });
 
-  test("closing during initialization cannot resurrect the session", async () => {
+  test("ready rejects when the session closes during initialization", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.deferReflectionSettingsResponse = true;
     const client = new LettaAgentClient({
@@ -1995,7 +1998,7 @@ describe("LettaAgentClient", () => {
       dreaming: { trigger: "step-count", stepCount: 3 },
     });
     try {
-      const initialize = asAdvanced(session).initialize();
+      const ready = session.ready();
       for (let i = 0; i < 100; i++) {
         if (FakeAppServerSocket.pendingReflectionSettingsResponse) break;
         await Promise.resolve();
@@ -2004,10 +2007,8 @@ describe("LettaAgentClient", () => {
 
       session.close();
       FakeAppServerSocket.pendingReflectionSettingsResponse?.();
-      await expect(initialize).rejects.toThrow();
-      await expect(asAdvanced(session).initialize()).rejects.toThrow(
-        "Session is closed",
-      );
+      await expect(ready).rejects.toThrow();
+      await expect(session.ready()).rejects.toThrow("Session is closed");
       expect(session.agentId).toBeNull();
       expect(session.sessionId).toBeNull();
       expect(session.conversationId).toBeNull();

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -818,9 +818,8 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("conv-1");
     try {
-      const init = await asAdvanced(session).initialize();
+      const init = await session.ready();
       expect(init).toMatchObject({
-        type: "init",
         agentId: "agent-from-conv",
         conversationId: "conv-1",
       });

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -6,6 +6,7 @@ type AssertFalse<T extends false> = T;
 type HasKey<K extends PropertyKey> = K extends keyof LettaCodeSession ? true : false;
 
 type _HasSend = AssertTrue<HasKey<"send">>;
+type _HasReady = AssertTrue<HasKey<"ready">>;
 type _HasStream = AssertTrue<HasKey<"stream">>;
 type _HasAbort = AssertTrue<HasKey<"abort">>;
 type _HasSendCommand = AssertTrue<HasKey<"sendCommand">>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -766,6 +766,11 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
 
 export interface LettaCodeSession extends AsyncDisposable {
   /**
+   * Initialize the session runtime and transport without sending a model
+   * request or fetching transcript history. Safe to call repeatedly.
+   */
+  ready(): Promise<SessionReadyInfo>;
+  /**
    * Send a user message. Pass `{ otid }` to supply your own correlation id for
    * optimistic reconciliation; the SDK generates one when omitted.
    */
@@ -827,6 +832,14 @@ export interface LettaCodeSession extends AsyncDisposable {
   readonly agentId: string | null;
   readonly sessionId: string | null;
   readonly conversationId: string | null;
+}
+
+/** Resolved session information returned by session.ready(). */
+export interface SessionReadyInfo {
+  agentId: string;
+  conversationId: string;
+  model: string | undefined;
+  tools?: string[];
 }
 
 export interface ChangeDeviceStateOptions {
@@ -1113,6 +1126,7 @@ export interface SDKResultMessage {
   /** Best-effort human-readable approval-conflict detail (if available). */
   errorDetail?: string;
   stopReason?: string;
+  /** Duration of the tracked turn in milliseconds. Excludes session initialization. */
   durationMs: number;
   totalCostUsd?: number;
   conversationId: string | null;


### PR DESCRIPTION
## Summary
- add idempotent `session.ready()` initialization
- reuse existing runtime and transport lifecycle without fetching transcript history
- document startup and turn timing semantics

## Testing
- `bun run check`
- `bun test`
- `bun run build`

Closes #297