### PR TITLE
feat(cloud): expose managed sandbox file transfer

### DIFF
--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -26,6 +26,7 @@ export class LettaAgentClient extends LettaAgentClientBase {
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 export { ConversationForkHydrationError } from "./management-errors.js";
 export { RepositoriesClient } from "./repositories.js";
+export type * from "./sandbox-files.js";
 export type {
   Computer,
   ComputerMetadata,

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -51,6 +51,13 @@ import {
   type LettaCodeCloudSandboxOptions,
   validateCloudSandboxOptions,
 } from "./cloud-sandbox.js";
+import {
+  downloadSandboxFile,
+  type SandboxFileUpload,
+  type SandboxFileUploadResult,
+  type SandboxFilesClient,
+  uploadSandboxFiles,
+} from "./sandbox-files.js";
 
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 const DEFAULT_PING_INTERVAL_MS = 30_000;
@@ -313,6 +320,7 @@ export function assertCloudSessionOptionsSupported(
 }
 
 export class CloudEnvironmentSession extends RemoteClientSessionCore {
+  readonly sandbox: SandboxFilesClient | undefined;
   private connectionId: string | null = null;
   private removeExternalToolHandler: (() => void) | null = null;
   private removeControlRequestHandler: (() => void) | null = null;
@@ -339,6 +347,12 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     });
     this.cloudMode = mode;
     this.repositoryManagement = new CloudManagementTransport(apiClient);
+    this.sandbox = this.effectiveEnvironment() === undefined
+      ? {
+          uploadFiles: (files) => this.uploadFilesToManagedSandbox(files),
+          downloadFile: (path) => this.downloadFileFromManagedSandbox(path),
+        }
+      : undefined;
     const tools = mode.options.tools;
     this.externalTools = externalToolsByName(tools);
   }
@@ -556,6 +570,31 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     const sandbox = this.managedSandbox;
     if (!sandbox) return;
     await this.refreshManagedSandbox(sandbox);
+  }
+
+  private async uploadFilesToManagedSandbox(
+    files: readonly SandboxFileUpload[],
+  ): Promise<SandboxFileUploadResult> {
+    const sandbox = await this.requireManagedSandboxForFileTransfer();
+    return uploadSandboxFiles(this.apiClient, sandbox.sandboxId, files);
+  }
+
+  private async downloadFileFromManagedSandbox(path: string): Promise<Uint8Array> {
+    const sandbox = await this.requireManagedSandboxForFileTransfer();
+    return downloadSandboxFile(this.apiClient, sandbox.sandboxId, path);
+  }
+
+  private async requireManagedSandboxForFileTransfer(): Promise<ManagedCloudSandbox> {
+    if (this.effectiveEnvironment() !== undefined) {
+      throw new Error("Sandbox file transfer requires an SDK-managed Cloud sandbox.");
+    }
+    await this.ready();
+    const sandbox = this.managedSandbox;
+    if (!sandbox) {
+      throw new Error("SDK-managed Cloud sandbox is unavailable.");
+    }
+    await this.refreshManagedSandbox(sandbox);
+    return sandbox;
   }
 
   protected override onCoreClose(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ export type {
   McpSseServerConfig,
   McpServers,
 } from "./types.js";
+export type * from "./sandbox-files.js";
 export type {
   AgentRepositoriesClient,
   AgentRepository,

--- a/src/sandbox-files.ts
+++ b/src/sandbox-files.ts
@@ -1,0 +1,97 @@
+import type Letta from "@letta-ai/letta-client";
+
+/** One file to upload into an SDK-managed Cloud sandbox. */
+export interface SandboxFileUpload {
+  /** Filename reported to the sandbox upload API. */
+  name: string;
+  /** Portable file contents. The Blob type supplies the MIME type. */
+  data: Blob;
+}
+
+/** Metadata returned after a file is uploaded into a managed sandbox. */
+export interface SandboxUploadedFile {
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface SandboxFileUploadResult {
+  files: SandboxUploadedFile[];
+}
+
+/** File transfer client for an SDK-managed Cloud sandbox. */
+export interface SandboxFilesClient {
+  /** Upload files under `/root/downloads` in this SDK-managed Cloud sandbox. */
+  uploadFiles(files: readonly SandboxFileUpload[]): Promise<SandboxFileUploadResult>;
+  /** Download one file under `/root/downloads` from this SDK-managed Cloud sandbox. */
+  downloadFile(path: string): Promise<Uint8Array>;
+}
+
+function isUploadedFile(value: unknown): value is SandboxUploadedFile {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const file = value as Record<string, unknown>;
+  return (
+    typeof file.path === "string" &&
+    typeof file.name === "string" &&
+    typeof file.mimeType === "string" &&
+    typeof file.size === "number" &&
+    Number.isSafeInteger(file.size) &&
+    file.size >= 0
+  );
+}
+
+function parseUploadResult(value: unknown): SandboxFileUploadResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Cloud sandbox file upload returned an invalid response.");
+  }
+  const files = (value as Record<string, unknown>).files;
+  if (!Array.isArray(files) || !files.every(isUploadedFile)) {
+    throw new Error("Cloud sandbox file upload returned invalid file metadata.");
+  }
+  return { files };
+}
+
+function uploadForm(files: readonly SandboxFileUpload[]): FormData {
+  if (files.length === 0) {
+    throw new Error("Cloud sandbox file upload requires at least one file.");
+  }
+  const form = new FormData();
+  for (const [index, file] of files.entries()) {
+    if (!file || typeof file.name !== "string" || file.name.trim() === "") {
+      throw new Error(`Invalid Cloud sandbox upload file at index ${index}.`);
+    }
+    form.append("file", file.data, file.name);
+  }
+  return form;
+}
+
+export async function uploadSandboxFiles(
+  apiClient: Letta,
+  sandboxId: string,
+  files: readonly SandboxFileUpload[],
+): Promise<SandboxFileUploadResult> {
+  const response = await apiClient.post<unknown>(
+    `/v1/sandboxes/${encodeURIComponent(sandboxId)}/files`,
+    { body: uploadForm(files) },
+  );
+  return parseUploadResult(response);
+}
+
+export async function downloadSandboxFile(
+  apiClient: Letta,
+  sandboxId: string,
+  path: string,
+): Promise<Uint8Array> {
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new Error("Cloud sandbox file download requires a non-empty path.");
+  }
+  const response = await apiClient.get<Response>(
+    `/v1/sandboxes/${encodeURIComponent(sandboxId)}/files`,
+    {
+      query: { path },
+      __binaryResponse: true,
+    },
+  );
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -43,6 +43,7 @@ function headersOf(init?: RequestInit): Record<string, string> {
 
 function bodyOf(init?: RequestInit): unknown {
   if (!init?.body) return undefined;
+  if (init.body instanceof FormData) return init.body;
   return JSON.parse(String(init.body));
 }
 
@@ -144,6 +145,36 @@ function createCloudFetchMock(
     const sandboxTerminateMatch = /^\/v1\/sandboxes\/([^/]+)\/terminate$/.exec(parsed.pathname);
     if (sandboxTerminateMatch && method === "POST") {
       return Promise.resolve(jsonResponse({ success: true, message: "terminated" }));
+    }
+
+    const sandboxFilesMatch = /^\/v1\/sandboxes\/([^/]+)\/files$/.exec(parsed.pathname);
+    if (sandboxFilesMatch && method === "POST") {
+      const form = init?.body;
+      if (!(form instanceof FormData)) {
+        return Promise.resolve(jsonResponse(
+          { errorCode: "NO_FILES", message: "No files were provided" },
+          { status: 400 },
+        ));
+      }
+      const files = form.getAll("file").map((part, index) => {
+        const blob = part as Blob & { name?: string };
+        const name = blob.name ?? `upload-${index}`;
+        return {
+          path: `/root/downloads/upload-1/${name}`,
+          name,
+          mimeType: blob.type,
+          size: blob.size,
+        };
+      });
+      return Promise.resolve(jsonResponse({ files }));
+    }
+
+    if (sandboxFilesMatch && method === "GET") {
+      const path = parsed.searchParams.get("path") ?? "";
+      return Promise.resolve(new Response(`download:${path}`, {
+        status: 200,
+        headers: { "Content-Type": "application/octet-stream" },
+      }));
     }
 
     const agentSandboxRefreshMatch = /^\/v1\/agents\/([^/]+)\/sandboxes\/refresh$/.exec(parsed.pathname);
@@ -840,6 +871,89 @@ describe("CloudEnvironmentSession", () => {
     } finally {
       session.close();
     }
+  });
+
+  test("uploads and downloads files through the managed sandbox", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      const uploaded = await session.sandbox!.uploadFiles([
+        {
+          name: "input.tar.gz",
+          data: new Blob(["archive"], { type: "application/gzip" }),
+        },
+        {
+          name: "context.json",
+          data: new Blob(["{}"], { type: "application/json" }),
+        },
+      ]);
+      expect(uploaded.files).toEqual([
+        {
+          path: "/root/downloads/upload-1/input.tar.gz",
+          name: "input.tar.gz",
+          mimeType: "application/gzip",
+          size: 7,
+        },
+        {
+          path: "/root/downloads/upload-1/context.json",
+          name: "context.json",
+          mimeType: "application/json;charset=utf-8",
+          size: 2,
+        },
+      ]);
+
+      const uploadRequest = requests.find((request) =>
+        request.method === "POST" &&
+        new URL(request.url).pathname ===
+          "/v1/sandboxes/sandbox-agent-from-conv/files"
+      );
+      expect(uploadRequest).toBeDefined();
+      expect(uploadRequest!.headers.authorization).toBe("Bearer sk-test");
+      expect(uploadRequest!.headers["content-type"]).toBeUndefined();
+      expect((uploadRequest!.body as FormData).getAll("file")).toHaveLength(2);
+      expect(requests.indexOf(uploadRequest!)).toBeGreaterThan(
+        requests.findIndex((request) =>
+          request.method === "POST" &&
+          new URL(request.url).pathname ===
+            "/v1/agents/agent-from-conv/sandboxes"
+        ),
+      );
+
+      const path = "/root/downloads/output/result.tar.gz";
+      const downloaded = await session.sandbox!.downloadFile(path);
+      expect(new TextDecoder().decode(downloaded)).toBe(`download:${path}`);
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "GET",
+        url: `https://api.test/v1/sandboxes/sandbox-agent-from-conv/files?path=${encodeURIComponent(path)}`,
+      }));
+    } finally {
+      session.close();
+    }
+  });
+
+  test("does not expose sandbox files for an explicit computer", () => {
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      computer: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("conv-1");
+    expect(session.sandbox).toBeUndefined();
+    session.close();
   });
 
   test("clones configured GitHub repositories into a managed sandbox", async () => {

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -7,6 +7,7 @@ type HasKey<K extends PropertyKey> = K extends keyof LettaCodeSession ? true : f
 
 type _HasSend = AssertTrue<HasKey<"send">>;
 type _HasReady = AssertTrue<HasKey<"ready">>;
+type _HasSandbox = AssertTrue<HasKey<"sandbox">>;
 type _HasStream = AssertTrue<HasKey<"stream">>;
 type _HasAbort = AssertTrue<HasKey<"abort">>;
 type _HasSendCommand = AssertTrue<HasKey<"sendCommand">>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -765,6 +765,8 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
 }
 
 export interface LettaCodeSession extends AsyncDisposable {
+  /** File transfer for the SDK-managed Cloud sandbox, when selected. */
+  readonly sandbox?: import("./sandbox-files.js").SandboxFilesClient;
   /**
    * Initialize the session runtime and transport without sending a model
    * request or fetching transcript history. Safe to call repeatedly.
@@ -833,7 +835,6 @@ export interface LettaCodeSession extends AsyncDisposable {
   readonly sessionId: string | null;
   readonly conversationId: string | null;
 }
-
 /** Resolved session information returned by session.ready(). */
 export interface SessionReadyInfo {
   agentId: string;
@@ -841,7 +842,6 @@ export interface SessionReadyInfo {
   model: string | undefined;
   tools?: string[];
 }
-
 export interface ChangeDeviceStateOptions {
   cwd?: string;
   permissionMode?: PermissionMode;


### PR DESCRIPTION
## Summary
- expose `session.sandbox.uploadFiles()` and `downloadFile()` for SDK-managed Cloud sandboxes
- initialize and refresh the existing managed sandbox before transfers, reusing the shared Letta API client for auth, retries, and errors
- keep the portable API unavailable when an explicit computer is selected

## Testing
- `bun run check`
- `bun test` (277 passed, 15 skipped)
- `bun run build`
- live `api.letta.com` upload/download round trip using `$LETTA_API_KEY`

[LET-11529](https://linear.app/letta/issue/LET-11529/expose-managed-sandbox-file-transfer-in-agent-sdk)

Unblocks [LET-11524](https://linear.app/letta/issue/LET-11524/run-planner-worker-agents-in-one-staged-cloud-sandbox).