### PR TITLE
fix(cloud): retry initial status transport

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -66,6 +66,7 @@ const DEFAULT_SANDBOX_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
 const DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS = 250;
+const INITIAL_CLOUD_TRANSPORT_ATTEMPTS = 2;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
 
 type CloudRuntimeStartResponse = ProtocolMessage & {
@@ -404,34 +405,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     runtime: RuntimeScope,
     connectionId: string,
   ): Promise<RuntimeSessionInit> {
-    const apiKey = getCloudApiKey(this.cloudOptions);
-    const url = buildCloudStatusWebSocketUrl({
-      apiBaseUrl: this.cloudOptions.apiBaseUrl,
-      connectionId,
-      agentId: runtime.agent_id,
-      conversationId: runtime.conversation_id,
-      apiKey,
-      authMode: this.cloudOptions.webSocketAuth ?? "header",
-    });
-    const client = applyUniqueRequestIds(createAppServerClient({
-      url,
-      WebSocket: createCloudStatusTransportConstructor({
-        url,
-        WebSocket: getWebSocketConstructor(this.cloudOptions.WebSocket),
-        ...((this.cloudOptions.webSocketAuth ?? "header") === "header"
-          ? { headers: cloudWebSocketHeaders(this.cloudOptions) }
-          : {}),
-        pingIntervalMs:
-          this.cloudOptions.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS,
-        runtime,
-      }),
-      requestTimeoutMs: this.cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
-    }));
+    const client = await this.connectCloudTransport(runtime, connectionId);
     const options = this.currentOptions();
-    this.installTransportHandlers(client);
 
     try {
-      await client.connect();
       const response = await this.startCloudRuntime(client, runtime);
       if (!response.success || !response.runtime) {
         throw new Error(response.error ?? "Failed to start Cloud status runtime");
@@ -471,6 +448,69 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       client.close();
       throw error;
     }
+  }
+
+  private createCloudTransportClient(
+    runtime: RuntimeScope,
+    connectionId: string,
+  ): AppServerClient {
+    const apiKey = getCloudApiKey(this.cloudOptions);
+    const url = buildCloudStatusWebSocketUrl({
+      apiBaseUrl: this.cloudOptions.apiBaseUrl,
+      connectionId,
+      agentId: runtime.agent_id,
+      conversationId: runtime.conversation_id,
+      apiKey,
+      authMode: this.cloudOptions.webSocketAuth ?? "header",
+    });
+    return applyUniqueRequestIds(createAppServerClient({
+      url,
+      WebSocket: createCloudStatusTransportConstructor({
+        url,
+        WebSocket: getWebSocketConstructor(this.cloudOptions.WebSocket),
+        ...((this.cloudOptions.webSocketAuth ?? "header") === "header"
+          ? { headers: cloudWebSocketHeaders(this.cloudOptions) }
+          : {}),
+        pingIntervalMs:
+          this.cloudOptions.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS,
+        runtime,
+      }),
+      requestTimeoutMs: this.cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
+    }));
+  }
+
+  private async connectCloudTransport(
+    runtime: RuntimeScope,
+    initialConnectionId: string,
+  ): Promise<AppServerClient> {
+    let connectionId = initialConnectionId;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < INITIAL_CLOUD_TRANSPORT_ATTEMPTS; attempt++) {
+      const client = this.createCloudTransportClient(runtime, connectionId);
+      this.installTransportHandlers(client);
+
+      try {
+        await client.connect();
+        this.connectionId = connectionId;
+        return client;
+      } catch (error) {
+        lastError = error;
+        this.cleanupTransportHandlers();
+        client.close();
+      }
+
+      if (attempt + 1 < INITIAL_CLOUD_TRANSPORT_ATTEMPTS) {
+        const resolved = await this.resolveRecoveryConnection(runtime);
+        connectionId = resolved.connectionId;
+      }
+    }
+
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+      `Cloud status WebSocket failed to open for connection ${connectionId}: ${detail}`,
+      { cause: lastError },
+    );
   }
 
   private installTransportHandlers(client: AppServerClient): void {

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -496,6 +496,21 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         return client;
       } catch (error) {
         lastError = error;
+        console.warn(
+          JSON.stringify({
+            event: "cloud_status_transport_connection_failed",
+            attempt: attempt + 1,
+            max_attempts: INITIAL_CLOUD_TRANSPORT_ATTEMPTS,
+            will_retry:
+              attempt + 1 < INITIAL_CLOUD_TRANSPORT_ATTEMPTS,
+            connection_id: connectionId,
+            agent_id: runtime.agent_id,
+            conversation_id: runtime.conversation_id,
+            error_name: error instanceof Error ? error.name : null,
+            error_message:
+              error instanceof Error ? error.message : String(error),
+          }),
+        );
         this.cleanupTransportHandlers();
         client.close();
       }

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   CloudManagedSandboxExpiredError,
@@ -1717,6 +1717,7 @@ describe("CloudEnvironmentSession", () => {
   test("retries an initial Cloud transport failure before sending input", async () => {
     resetFakeCloud();
     FakeCloudSocket.openConnectionFailuresRemaining = 1;
+    const warningSpy = spyOn(console, "warn").mockImplementation(() => {});
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
       backend: "cloud",
@@ -1751,14 +1752,29 @@ describe("CloudEnvironmentSession", () => {
           new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes"
         ),
       ).toHaveLength(1);
+      expect(warningSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(warningSpy.mock.calls[0]?.[0]))).toEqual({
+        event: "cloud_status_transport_connection_failed",
+        attempt: 1,
+        max_attempts: 2,
+        will_retry: true,
+        connection_id: "conn-agent-1",
+        agent_id: "agent-1",
+        conversation_id: "default",
+        error_name: "Error",
+        error_message:
+          "App-server WebSocket failed to open: Error: initial socket open failed",
+      });
     } finally {
       session.close();
+      warningSpy.mockRestore();
     }
   });
 
   test("bounds initial Cloud transport retries before runtime start", async () => {
     resetFakeCloud();
     FakeCloudSocket.openConnectionFailuresRemaining = 2;
+    const warningSpy = spyOn(console, "warn").mockImplementation(() => {});
     const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
@@ -1781,8 +1797,27 @@ describe("CloudEnvironmentSession", () => {
       expect(
         FakeCloudSocket.allSent().filter((command) => command.type === "input"),
       ).toHaveLength(0);
+      expect(
+        warningSpy.mock.calls.map(([line]) => JSON.parse(String(line))),
+      ).toEqual([
+        expect.objectContaining({
+          event: "cloud_status_transport_connection_failed",
+          attempt: 1,
+          max_attempts: 2,
+          will_retry: true,
+          connection_id: "conn-explicit",
+        }),
+        expect.objectContaining({
+          event: "cloud_status_transport_connection_failed",
+          attempt: 2,
+          max_attempts: 2,
+          will_retry: false,
+          connection_id: "conn-explicit",
+        }),
+      ]);
     } finally {
       session.close();
+      warningSpy.mockRestore();
     }
   });
 

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -291,6 +291,8 @@ class FakeCloudSocket {
     | "hang" = "normal";
   static syncSucceeds = true;
   static deviceStatusOnSync = false;
+  static openConnectionFailuresRemaining = 0;
+  private static currentConnectionShouldFail = false;
   readyState = 0;
   sent: Array<Record<string, unknown>> = [];
   private listeners = new Map<string, Set<Listener>>();
@@ -300,7 +302,21 @@ class FakeCloudSocket {
     readonly options?: { headers?: Record<string, string> },
   ) {
     FakeCloudSocket.instances.push(this);
+    const channel = new URL(url).searchParams.get("channel");
+    if (channel === "control") {
+      FakeCloudSocket.currentConnectionShouldFail =
+        FakeCloudSocket.openConnectionFailuresRemaining > 0;
+      if (FakeCloudSocket.currentConnectionShouldFail) {
+        FakeCloudSocket.openConnectionFailuresRemaining--;
+      }
+    }
+    const shouldFail = FakeCloudSocket.currentConnectionShouldFail;
     queueMicrotask(() => {
+      if (shouldFail) {
+        this.readyState = 3;
+        this.emit("error", new Error("initial socket open failed"));
+        return;
+      }
       this.readyState = 1;
       this.emit("open", {});
     });
@@ -702,6 +718,7 @@ function resetFakeCloud(): void {
   FakeCloudSocket.scenario = "normal";
   FakeCloudSocket.syncSucceeds = true;
   FakeCloudSocket.deviceStatusOnSync = false;
+  FakeCloudSocket.openConnectionFailuresRemaining = 0;
 }
 
 describe("CloudEnvironmentSession", () => {
@@ -1692,6 +1709,78 @@ describe("CloudEnvironmentSession", () => {
           new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes"
         ),
       ).toHaveLength(1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("retries an initial Cloud transport failure before sending input", async () => {
+    resetFakeCloud();
+    FakeCloudSocket.openConnectionFailuresRemaining = 1;
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("agent-1");
+    try {
+      const result = await asAdvanced(session).sendAndWaitForResult("hello once");
+      expect(result).toMatchObject({
+        success: true,
+        result: "hello from cloud",
+      });
+
+      expect(FakeCloudSocket.instances).toHaveLength(4);
+      expect(
+        FakeCloudSocket.allSent().filter((command) => command.type === "runtime_start"),
+      ).toHaveLength(1);
+      expect(
+        FakeCloudSocket.allSent().filter((command) => {
+          const payload = command.payload as { kind?: string } | undefined;
+          return command.type === "input" && payload?.kind === "create_message";
+        }),
+      ).toHaveLength(1);
+      expect(
+        requests.filter((request) =>
+          request.method === "POST" &&
+          new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes"
+        ),
+      ).toHaveLength(1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("bounds initial Cloud transport retries before runtime start", async () => {
+    resetFakeCloud();
+    FakeCloudSocket.openConnectionFailuresRemaining = 2;
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      environment: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("agent-1");
+    try {
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "Cloud status WebSocket failed to open for connection conn-explicit",
+      );
+      expect(FakeCloudSocket.instances).toHaveLength(4);
+      expect(
+        FakeCloudSocket.allSent().filter((command) => command.type === "runtime_start"),
+      ).toHaveLength(0);
+      expect(
+        FakeCloudSocket.allSent().filter((command) => command.type === "input"),
+      ).toHaveLength(0);
     } finally {
       session.close();
     }


### PR DESCRIPTION
## tl;dr

**Type:** Bug fix

**Goal:** Keep a transient initial Cloud status WebSocket failure from consuming an agent turn, while preserving enough information to diagnose the failed connection.

**What was missing:** A Cloud session made one attempt to open its initial App-server WebSocket pair. If that failed, session initialization ended before `runtime_start` or user input, and the failed connection was not logged.

**What changed:** The Agent SDK now closes the failed socket pair, refreshes or re-resolves the current listener, and tries once more with fresh sockets. Every failed attempt emits a structured `cloud_status_transport_connection_failed` warning.

## Before and after

**Before:**

1. Resolve the managed sandbox listener.
2. Open the Cloud status WebSocket pair.
3. If either socket fails to open, fail session initialization.
4. No `runtime_start` or user input is sent.

**After:**

1. Resolve the managed sandbox listener.
2. Open the Cloud status WebSocket pair.
3. If it fails, log the failed connection, close both sockets, and re-resolve the listener.
4. Open one fresh socket pair.
5. Only after a connection succeeds, send `runtime_start` and user input.
6. If both attempts fail, preserve the existing terminal failure behavior with the final connection ID.

This is bounded startup recovery. It does not retry a disconnect after input may have reached the listener, and it does not claim to identify the underlying relay failure.

## Review notes

**Merge when:** CI passes on the current head and the retry remains entirely before `runtime_start` and input.

**Start here:** `CloudEnvironmentSession.connectCloudTransport()` in `src/cloud-session.ts`, then the three transport-boundary tests in `src/tests/cloud-session.test.ts`.

**Risk:** `AppServerClient.connect()` failures are retried as one class. The boundary must remain pre-protocol so retrying cannot duplicate a turn.

## Testing

**Automated:**

- `bun run check` (passed)
- `bun test` (279 passed, 15 live tests skipped)
- `bun run build` (passed)
- Added coverage for one recovered socket-open failure, two exhausted failures, structured warnings for both outcomes, and a post-input disconnect that remains terminal.

**Not tested:** No live relay failure was injected. The deterministic socket tests reproduce the connection boundary and frame ordering.

**Observability:** Each failed connection writes one JSON warning with attempt count, whether another retry will run, connection ID, agent ID, conversation ID, and the underlying error name and message. A successful second connection no longer erases the first failure from process logs.

## Breadcrumbs

- Linear: LET-11610
- Origin: [#146](https://github.com/letta-ai/letta-agent-sdk/pull/146) added the original Cloud remote environment transport with one socket-open attempt; history found no later regression.
