### PR TITLE
fix: settle turns when terminal usage is absent

### DIFF
--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -151,7 +151,6 @@ export type TurnTracker = {
   observedTurnEvidence: boolean;
   observedRequiresApprovalStop: boolean;
   pendingTerminal: RuntimeTurnResult | null;
-  pendingTerminalTimeout: ReturnType<typeof setTimeout> | null;
   abortRequested: boolean;
   timeout: ReturnType<typeof setTimeout> | null;
 };

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -153,6 +153,7 @@ export type TurnTracker = {
   pendingTerminal: RuntimeTurnResult | null;
   pendingTerminalTimeout: ReturnType<typeof setTimeout> | null;
   deferredMessages: ProtocolMessage[];
+  deferredTurnEvidence: boolean;
   abortRequested: boolean;
   timeout: ReturnType<typeof setTimeout> | null;
 };

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -151,6 +151,7 @@ export type TurnTracker = {
   observedTurnEvidence: boolean;
   observedRequiresApprovalStop: boolean;
   pendingTerminal: RuntimeTurnResult | null;
+  pendingTerminalTimeout: ReturnType<typeof setTimeout> | null;
   abortRequested: boolean;
   timeout: ReturnType<typeof setTimeout> | null;
 };

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -151,6 +151,8 @@ export type TurnTracker = {
   observedTurnEvidence: boolean;
   observedRequiresApprovalStop: boolean;
   pendingTerminal: RuntimeTurnResult | null;
+  pendingTerminalTimeout: ReturnType<typeof setTimeout> | null;
+  deferredMessages: ProtocolMessage[];
   abortRequested: boolean;
   timeout: ReturnType<typeof setTimeout> | null;
 };

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -171,6 +171,10 @@ export class RemoteTurnCoordinator {
         this.handleLoopStatusMessage(message);
         return;
       }
+      if (message.type === "update_loop_status" && statusRunIds.length === 0) {
+        trailingUsageTurn.deferredMessages.push(message);
+        return;
+      }
       const isTurnScoped =
         deferredDelta !== null ||
         message.type === "update_loop_status" ||

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -105,6 +105,7 @@ export class RemoteTurnCoordinator {
       pendingTerminal: null,
       pendingTerminalTimeout: null,
       deferredMessages: [],
+      deferredTurnEvidence: false,
       abortRequested: false,
       timeout: null,
     };
@@ -146,15 +147,25 @@ export class RemoteTurnCoordinator {
     const deferredMessageType = deferredDelta
       ? streamDeltaMessageType(deferredDelta)
       : undefined;
-    if (
-      this.activeTurn?.pendingTerminalTimeout &&
-      (
-        deferredMessageType !== "usage_statistics" ||
-        this.activeTurn.deferredMessages.length > 0
-      )
-    ) {
-      this.activeTurn.deferredMessages.push(message);
-      return;
+    const trailingUsageTurn = this.activeTurn?.pendingTerminalTimeout
+      ? this.activeTurn
+      : null;
+    if (trailingUsageTurn) {
+      const successorEvidence =
+        deferredMessageType === "assistant_message" ||
+        deferredMessageType === "reasoning_message" ||
+        deferredMessageType === "tool_call_message" ||
+        deferredMessageType === "tool_return_message" ||
+        deferredMessageType === "stop_reason" ||
+        turnFinishedRecord(message) !== null;
+      if (
+        successorEvidence ||
+        (deferredMessageType === "usage_statistics" && trailingUsageTurn.deferredTurnEvidence)
+      ) {
+        trailingUsageTurn.deferredMessages.push(message);
+        if (successorEvidence) trailingUsageTurn.deferredTurnEvidence = true;
+        return;
+      }
     }
 
     if (message.type === "update_queue") {
@@ -219,6 +230,11 @@ export class RemoteTurnCoordinator {
     if (this.closed) return;
     const active = this.activeTurn;
     if (active) {
+      if (active.pendingTerminal && active.pendingTerminalTimeout) {
+        this.completeActiveTurn(active.pendingTerminal);
+        this.close();
+        return;
+      }
       this.failTurn(active, detail, {
         errorCode: "stream_closed",
         recoverable: true,

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -176,7 +176,7 @@ export class RemoteTurnCoordinator {
         return;
       }
       const isTurnScoped =
-        deferredDelta !== null ||
+        (deferredDelta !== null && deferredMessageType !== "ping") ||
         message.type === "update_loop_status" ||
         turnFinishedRecord(message) !== null;
       if (

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -143,6 +143,15 @@ export class RemoteTurnCoordinator {
       return;
     }
 
+    if (message.type === "update_queue") {
+      const sdkMessage: SDKQueueUpdateMessage = {
+        type: "queue_update",
+        queue: queueItems(message),
+      };
+      this.enqueue(sdkMessage);
+      return;
+    }
+
     const deferredDelta = streamDeltaRecord(message);
     const deferredMessageType = deferredDelta
       ? streamDeltaMessageType(deferredDelta)
@@ -151,30 +160,16 @@ export class RemoteTurnCoordinator {
       ? this.activeTurn
       : null;
     if (trailingUsageTurn) {
-      const successorEvidence =
-        deferredMessageType === "assistant_message" ||
-        deferredMessageType === "reasoning_message" ||
-        deferredMessageType === "tool_call_message" ||
-        deferredMessageType === "tool_return_message" ||
-        deferredMessageType === "stop_reason" ||
-        turnFinishedRecord(message) !== null;
       if (
-        successorEvidence ||
+        deferredMessageType !== "usage_statistics" ||
         (deferredMessageType === "usage_statistics" && trailingUsageTurn.deferredTurnEvidence)
       ) {
         trailingUsageTurn.deferredMessages.push(message);
-        if (successorEvidence) trailingUsageTurn.deferredTurnEvidence = true;
+        if (deferredMessageType !== "usage_statistics") {
+          trailingUsageTurn.deferredTurnEvidence = true;
+        }
         return;
       }
-    }
-
-    if (message.type === "update_queue") {
-      const sdkMessage: SDKQueueUpdateMessage = {
-        type: "queue_update",
-        queue: queueItems(message),
-      };
-      this.enqueue(sdkMessage);
-      return;
     }
 
     if (message.type === "update_loop_status") {
@@ -228,18 +223,18 @@ export class RemoteTurnCoordinator {
    */
   closeWithError(detail: string): void {
     if (this.closed) return;
+    let completedCanonicalTurn = false;
+    while (this.activeTurn?.pendingTerminal && this.activeTurn.pendingTerminalTimeout) {
+      this.completeActiveTurn(this.activeTurn.pendingTerminal);
+      completedCanonicalTurn = true;
+    }
     const active = this.activeTurn;
     if (active) {
-      if (active.pendingTerminal && active.pendingTerminalTimeout) {
-        this.completeActiveTurn(active.pendingTerminal);
-        this.close();
-        return;
-      }
       this.failTurn(active, detail, {
         errorCode: "stream_closed",
         recoverable: true,
       });
-    } else {
+    } else if (!completedCanonicalTurn) {
       this.enqueue({
         type: "error",
         message: detail,

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -43,6 +43,7 @@ type RemoteTurnCoordinatorConfig = {
 };
 
 const MAX_RECENTLY_SETTLED_RUN_IDS = 256;
+const TRAILING_USAGE_GRACE_MS = 100;
 
 /**
  * Owns the portable session's turn correlation and stream queue.
@@ -102,6 +103,8 @@ export class RemoteTurnCoordinator {
       observedTurnEvidence: false,
       observedRequiresApprovalStop: false,
       pendingTerminal: null,
+      pendingTerminalTimeout: null,
+      deferredMessages: [],
       abortRequested: false,
       timeout: null,
     };
@@ -116,6 +119,7 @@ export class RemoteTurnCoordinator {
 
   removeTrackedTurn(turn: TurnTracker): void {
     if (turn.timeout) clearTimeout(turn.timeout);
+    if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     if (this.activeTurn === turn) {
       this.activeTurn = null;
       return;
@@ -135,6 +139,21 @@ export class RemoteTurnCoordinator {
     if (statusRecord) {
       const status = toSessionDeviceStatus(statusRecord);
       if (status) this.onDeviceStatus(status);
+      return;
+    }
+
+    const deferredDelta = streamDeltaRecord(message);
+    const deferredMessageType = deferredDelta
+      ? streamDeltaMessageType(deferredDelta)
+      : undefined;
+    if (
+      this.activeTurn?.pendingTerminalTimeout &&
+      (
+        deferredMessageType !== "usage_statistics" ||
+        this.activeTurn.deferredMessages.length > 0
+      )
+    ) {
+      this.activeTurn.deferredMessages.push(message);
       return;
     }
 
@@ -221,8 +240,12 @@ export class RemoteTurnCoordinator {
     if (this.closed) return;
     this.closed = true;
     if (this.activeTurn?.timeout) clearTimeout(this.activeTurn.timeout);
+    if (this.activeTurn?.pendingTerminalTimeout) {
+      clearTimeout(this.activeTurn.pendingTerminalTimeout);
+    }
     for (const turn of this.pendingTurns) {
       if (turn.timeout) clearTimeout(turn.timeout);
+      if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     }
     this.activeTurn = null;
     this.pendingTurns.length = 0;
@@ -282,9 +305,17 @@ export class RemoteTurnCoordinator {
       clearTimeout(active.timeout);
       active.timeout = null;
     }
+    if (active.pendingTerminalTimeout) {
+      clearTimeout(active.pendingTerminalTimeout);
+      active.pendingTerminalTimeout = null;
+    }
+    const deferredMessages = active.deferredMessages.splice(0);
     this.rememberSettledRunIds(active.runIds);
     this.enqueue(this.resultFromTurn(turn, active));
     this.activeTurn = null;
+    for (const message of deferredMessages) {
+      this.handleProtocolMessage(message, active.runtime);
+    }
   }
 
   private rememberSettledRunIds(runIds: Iterable<string>): void {
@@ -385,6 +416,15 @@ export class RemoteTurnCoordinator {
       ...(success ? {} : { errorCode: errorCode ?? "error" }),
       ...(finished.error ? { detail: finished.error } : {}),
     } satisfies RuntimeTurnResult;
+    if (active.pendingTerminal) {
+      active.pendingTerminal = terminal;
+      if (active.timeout) {
+        clearTimeout(active.timeout);
+        active.timeout = null;
+      }
+      this.schedulePendingTerminal(active);
+      return;
+    }
     this.completeActiveTurn(terminal);
   }
 
@@ -401,8 +441,8 @@ export class RemoteTurnCoordinator {
         active.observedRequiresApprovalStop = true;
         return;
       }
-      // Keep the stop reason as a fallback until the correlated
-      // turn_finished receipt provides canonical completion.
+      // Hosted streams send final usage after stop_reason. Keep result last so
+      // consumers that stop at result cannot miss the accounting event.
       active.pendingTerminal = {
         runtime: active.runtime,
         stopReason,
@@ -412,9 +452,9 @@ export class RemoteTurnCoordinator {
     }
 
     if (messageType === "usage_statistics" && active.pendingTerminal) {
-      // Usage frames carry no run id, so they cannot safely settle a turn when
-      // several sends are queued. The correlated turn_finished receipt owns
-      // completion; usage remains observable in the stream.
+      if (active.pendingTerminalTimeout) {
+        this.completeActiveTurn(active.pendingTerminal);
+      }
       return;
     }
 
@@ -428,6 +468,15 @@ export class RemoteTurnCoordinator {
         errorCode: sdkMessage.errorCode,
       });
     }
+  }
+
+  private schedulePendingTerminal(active: TurnTracker): void {
+    if (active.pendingTerminalTimeout) return;
+    active.pendingTerminalTimeout = setTimeout(() => {
+      if (this.activeTurn !== active || !active.pendingTerminal) return;
+      this.completeActiveTurn(active.pendingTerminal);
+    }, TRAILING_USAGE_GRACE_MS);
+    (active.pendingTerminalTimeout as { unref?: () => void }).unref?.();
   }
 
   private transformStreamDelta(

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -43,6 +43,7 @@ type RemoteTurnCoordinatorConfig = {
 };
 
 const MAX_RECENTLY_SETTLED_RUN_IDS = 256;
+const TRAILING_USAGE_GRACE_MS = 100;
 
 /**
  * Owns the portable session's turn correlation and stream queue.
@@ -66,6 +67,7 @@ export class RemoteTurnCoordinator {
   private clientMessageCounter = 0;
   private closed = false;
   private _activeTurnStartedAt = 0;
+  private discardNextUncorrelatedUsage = false;
 
   constructor(config: RemoteTurnCoordinatorConfig) {
     this.label = config.label;
@@ -102,6 +104,7 @@ export class RemoteTurnCoordinator {
       observedTurnEvidence: false,
       observedRequiresApprovalStop: false,
       pendingTerminal: null,
+      pendingTerminalTimeout: null,
       abortRequested: false,
       timeout: null,
     };
@@ -116,6 +119,7 @@ export class RemoteTurnCoordinator {
 
   removeTrackedTurn(turn: TurnTracker): void {
     if (turn.timeout) clearTimeout(turn.timeout);
+    if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     if (this.activeTurn === turn) {
       this.activeTurn = null;
       return;
@@ -160,7 +164,21 @@ export class RemoteTurnCoordinator {
 
     const delta = streamDeltaRecord(message);
     if (!delta) return;
-    const active = this.activateNextTurnFromProtocol();
+    const messageType = streamDeltaMessageType(delta);
+    // Terminal metadata can trail the result it belongs to. It must never
+    // activate a queued turn or become evidence for that next turn.
+    const active =
+      messageType === "usage_statistics" || messageType === "stop_reason"
+        ? this.activeTurn
+        : this.activateNextTurnFromProtocol();
+    if (
+      messageType === "usage_statistics" &&
+      this.discardNextUncorrelatedUsage &&
+      !active?.pendingTerminal
+    ) {
+      this.discardNextUncorrelatedUsage = false;
+      return;
+    }
     if (active) {
       active.observedTurnEvidence = true;
       const runId = streamDeltaRunId(delta);
@@ -215,8 +233,12 @@ export class RemoteTurnCoordinator {
     if (this.closed) return;
     this.closed = true;
     if (this.activeTurn?.timeout) clearTimeout(this.activeTurn.timeout);
+    if (this.activeTurn?.pendingTerminalTimeout) {
+      clearTimeout(this.activeTurn.pendingTerminalTimeout);
+    }
     for (const turn of this.pendingTurns) {
       if (turn.timeout) clearTimeout(turn.timeout);
+      if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     }
     this.activeTurn = null;
     this.pendingTurns.length = 0;
@@ -275,6 +297,10 @@ export class RemoteTurnCoordinator {
     if (active.timeout) {
       clearTimeout(active.timeout);
       active.timeout = null;
+    }
+    if (active.pendingTerminalTimeout) {
+      clearTimeout(active.pendingTerminalTimeout);
+      active.pendingTerminalTimeout = null;
     }
     this.rememberSettledRunIds(active.runIds);
     this.enqueue(this.resultFromTurn(turn, active));
@@ -380,6 +406,14 @@ export class RemoteTurnCoordinator {
     } satisfies RuntimeTurnResult;
     if (active.pendingTerminal) {
       active.pendingTerminal = terminal;
+      // A correlated turn_finished is canonical completion evidence. The
+      // request itself can no longer time out while we briefly wait for the
+      // optional trailing usage frame.
+      if (active.timeout) {
+        clearTimeout(active.timeout);
+        active.timeout = null;
+      }
+      this.schedulePendingTerminal(active);
       return;
     }
     this.completeActiveTurn(terminal);
@@ -423,6 +457,16 @@ export class RemoteTurnCoordinator {
         errorCode: sdkMessage.errorCode,
       });
     }
+  }
+
+  private schedulePendingTerminal(active: TurnTracker): void {
+    if (active.pendingTerminalTimeout) return;
+    active.pendingTerminalTimeout = setTimeout(() => {
+      if (this.activeTurn !== active || !active.pendingTerminal) return;
+      this.discardNextUncorrelatedUsage = true;
+      this.completeActiveTurn(active.pendingTerminal);
+    }, TRAILING_USAGE_GRACE_MS);
+    (active.pendingTerminalTimeout as { unref?: () => void }).unref?.();
   }
 
   private transformStreamDelta(

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -160,12 +160,27 @@ export class RemoteTurnCoordinator {
       ? this.activeTurn
       : null;
     if (trailingUsageTurn) {
+      const statusRunIds = message.type === "update_loop_status"
+        ? loopStatusRunIds(message)
+        : [];
+      const belongsToTerminalTurn =
+        message.type === "update_loop_status" &&
+        statusRunIds.length > 0 &&
+        statusRunIds.every((runId) => trailingUsageTurn.runIds.has(runId));
+      if (belongsToTerminalTurn) {
+        this.handleLoopStatusMessage(message);
+        return;
+      }
+      const isTurnScoped =
+        deferredDelta !== null ||
+        message.type === "update_loop_status" ||
+        turnFinishedRecord(message) !== null;
       if (
-        deferredMessageType !== "usage_statistics" ||
+        (isTurnScoped && deferredMessageType !== "usage_statistics") ||
         (deferredMessageType === "usage_statistics" && trailingUsageTurn.deferredTurnEvidence)
       ) {
         trailingUsageTurn.deferredMessages.push(message);
-        if (deferredMessageType !== "usage_statistics") {
+        if (isTurnScoped && deferredMessageType !== "usage_statistics") {
           trailingUsageTurn.deferredTurnEvidence = true;
         }
         return;

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -173,8 +173,7 @@ export class RemoteTurnCoordinator {
         : this.activateNextTurnFromProtocol();
     if (
       messageType === "usage_statistics" &&
-      this.discardNextUncorrelatedUsage &&
-      !active?.pendingTerminal
+      this.discardNextUncorrelatedUsage
     ) {
       this.discardNextUncorrelatedUsage = false;
       return;
@@ -373,9 +372,10 @@ export class RemoteTurnCoordinator {
     stopReason: string;
     error?: string;
   }): void {
-    const active = this.activeTurn;
-    if (!active || !finished.runId) return;
+    if (!finished.runId) return;
     if (this.settledRunIds.has(finished.runId)) return;
+    const active = this.activeTurn ?? this.activateNextTurnFromProtocol();
+    if (!active) return;
     if (
       active.runIds.size > 0 &&
       !active.runIds.has(finished.runId)

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -43,7 +43,6 @@ type RemoteTurnCoordinatorConfig = {
 };
 
 const MAX_RECENTLY_SETTLED_RUN_IDS = 256;
-const TRAILING_USAGE_GRACE_MS = 100;
 
 /**
  * Owns the portable session's turn correlation and stream queue.
@@ -67,7 +66,6 @@ export class RemoteTurnCoordinator {
   private clientMessageCounter = 0;
   private closed = false;
   private _activeTurnStartedAt = 0;
-  private discardNextUncorrelatedUsage = false;
 
   constructor(config: RemoteTurnCoordinatorConfig) {
     this.label = config.label;
@@ -104,7 +102,6 @@ export class RemoteTurnCoordinator {
       observedTurnEvidence: false,
       observedRequiresApprovalStop: false,
       pendingTerminal: null,
-      pendingTerminalTimeout: null,
       abortRequested: false,
       timeout: null,
     };
@@ -119,7 +116,6 @@ export class RemoteTurnCoordinator {
 
   removeTrackedTurn(turn: TurnTracker): void {
     if (turn.timeout) clearTimeout(turn.timeout);
-    if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     if (this.activeTurn === turn) {
       this.activeTurn = null;
       return;
@@ -171,13 +167,6 @@ export class RemoteTurnCoordinator {
       messageType === "usage_statistics" || messageType === "stop_reason"
         ? this.activeTurn
         : this.activateNextTurnFromProtocol();
-    if (
-      messageType === "usage_statistics" &&
-      this.discardNextUncorrelatedUsage
-    ) {
-      this.discardNextUncorrelatedUsage = false;
-      return;
-    }
     if (active) {
       active.observedTurnEvidence = true;
       const runId = streamDeltaRunId(delta);
@@ -232,12 +221,8 @@ export class RemoteTurnCoordinator {
     if (this.closed) return;
     this.closed = true;
     if (this.activeTurn?.timeout) clearTimeout(this.activeTurn.timeout);
-    if (this.activeTurn?.pendingTerminalTimeout) {
-      clearTimeout(this.activeTurn.pendingTerminalTimeout);
-    }
     for (const turn of this.pendingTurns) {
       if (turn.timeout) clearTimeout(turn.timeout);
-      if (turn.pendingTerminalTimeout) clearTimeout(turn.pendingTerminalTimeout);
     }
     this.activeTurn = null;
     this.pendingTurns.length = 0;
@@ -296,10 +281,6 @@ export class RemoteTurnCoordinator {
     if (active.timeout) {
       clearTimeout(active.timeout);
       active.timeout = null;
-    }
-    if (active.pendingTerminalTimeout) {
-      clearTimeout(active.pendingTerminalTimeout);
-      active.pendingTerminalTimeout = null;
     }
     this.rememberSettledRunIds(active.runIds);
     this.enqueue(this.resultFromTurn(turn, active));
@@ -404,18 +385,6 @@ export class RemoteTurnCoordinator {
       ...(success ? {} : { errorCode: errorCode ?? "error" }),
       ...(finished.error ? { detail: finished.error } : {}),
     } satisfies RuntimeTurnResult;
-    if (active.pendingTerminal) {
-      active.pendingTerminal = terminal;
-      // A correlated turn_finished is canonical completion evidence. The
-      // request itself can no longer time out while we briefly wait for the
-      // optional trailing usage frame.
-      if (active.timeout) {
-        clearTimeout(active.timeout);
-        active.timeout = null;
-      }
-      this.schedulePendingTerminal(active);
-      return;
-    }
     this.completeActiveTurn(terminal);
   }
 
@@ -432,8 +401,8 @@ export class RemoteTurnCoordinator {
         active.observedRequiresApprovalStop = true;
         return;
       }
-      // Hosted streams send final usage after stop_reason. Keep result last so
-      // consumers that stop at result cannot miss the accounting event.
+      // Keep the stop reason as a fallback until the correlated
+      // turn_finished receipt provides canonical completion.
       active.pendingTerminal = {
         runtime: active.runtime,
         stopReason,
@@ -443,7 +412,9 @@ export class RemoteTurnCoordinator {
     }
 
     if (messageType === "usage_statistics" && active.pendingTerminal) {
-      this.completeActiveTurn(active.pendingTerminal);
+      // Usage frames carry no run id, so they cannot safely settle a turn when
+      // several sends are queued. The correlated turn_finished receipt owns
+      // completion; usage remains observable in the stream.
       return;
     }
 
@@ -457,16 +428,6 @@ export class RemoteTurnCoordinator {
         errorCode: sdkMessage.errorCode,
       });
     }
-  }
-
-  private schedulePendingTerminal(active: TurnTracker): void {
-    if (active.pendingTerminalTimeout) return;
-    active.pendingTerminalTimeout = setTimeout(() => {
-      if (this.activeTurn !== active || !active.pendingTerminal) return;
-      this.discardNextUncorrelatedUsage = true;
-      this.completeActiveTurn(active.pendingTerminal);
-    }, TRAILING_USAGE_GRACE_MS);
-    (active.pendingTerminalTimeout as { unref?: () => void }).unref?.();
   }
 
   private transformStreamDelta(

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -39,6 +39,7 @@ class FakeAppServerSocket {
     | "delayedApprovalRequest"
     | "manualApprovalWait"
     | "queuedSecond"
+    | "terminalWithoutUsage"
     | "hang" = "normal";
   static failNextRuntimeStart = false;
   static deferReflectionSettingsResponse = false;
@@ -683,6 +684,25 @@ function fakeAppServerHandle(
       },
     };
     emitStream(assistantDelta);
+    if (FakeAppServerSocket.inputScenario === "terminalWithoutUsage") {
+      emitStream({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+          run_id: "run-1",
+        },
+      });
+      emitStream({
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-run-1",
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      });
+      return;
+    }
     emitSuccessfulTerminal("run-1");
   }
 }
@@ -1042,6 +1062,30 @@ describe("LettaAgentClient", () => {
       expect(payload).not.toHaveProperty("supports_control_response");
       expect(payload).not.toHaveProperty("source");
     } finally {
+      session.close();
+    }
+  });
+
+  test("result-only turns settle when terminal usage is absent", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "terminalWithoutUsage";
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      const result = await asAdvanced(session).sendAndWaitForResult("hello");
+      expect(result).toMatchObject({
+        type: "result",
+        success: true,
+        result: "hello from app-server",
+        runIds: ["run-1"],
+      });
+    } finally {
+      FakeAppServerSocket.inputScenario = "normal";
       session.close();
     }
   });

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -822,7 +822,7 @@ describe("CloudEnvironmentSession", () => {
     );
   });
 
-  test("settles from hosted turn_finished when usage follows on another channel", async () => {
+  test("keeps hosted usage after stop ahead of the terminal result", async () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "usage_after_stop";
     const requests: RecordedRequest[] = [];
@@ -844,9 +844,17 @@ describe("CloudEnvironmentSession", () => {
 
       expect(messages.map((message) => message.type)).toEqual([
         "assistant",
+        "stream_event",
         "result",
       ]);
       expect(messages[1]).toMatchObject({
+        type: "stream_event",
+        event: {
+          message_type: "usage_statistics",
+          step_count: 3,
+        },
+      });
+      expect(messages[2]).toMatchObject({
         type: "result",
         success: true,
         runIds: ["run-cloud-usage"],

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -822,7 +822,7 @@ describe("CloudEnvironmentSession", () => {
     );
   });
 
-  test("keeps hosted usage after stop ahead of the terminal result", async () => {
+  test("settles from hosted turn_finished when usage follows on another channel", async () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "usage_after_stop";
     const requests: RecordedRequest[] = [];
@@ -844,17 +844,9 @@ describe("CloudEnvironmentSession", () => {
 
       expect(messages.map((message) => message.type)).toEqual([
         "assistant",
-        "stream_event",
         "result",
       ]);
       expect(messages[1]).toMatchObject({
-        type: "stream_event",
-        event: {
-          message_type: "usage_statistics",
-          step_count: 3,
-        },
-      });
-      expect(messages[2]).toMatchObject({
         type: "result",
         success: true,
         runIds: ["run-cloud-usage"],

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -736,6 +736,99 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("defers a queued successor arriving during the prior turn's usage grace", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "first",
+        run_id: "run-first-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-first-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first-grace",
+        run_id: "run-first-grace",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "second",
+        run_id: "run-second-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-second-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 222,
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-second-during-grace",
+        run_id: "run-second-during-grace",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "first",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      result: "first",
+      runIds: ["run-first-grace"],
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "second",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 222 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      result: "second",
+      runIds: ["run-second-during-grace"],
+    });
+    coordinator.close();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -1136,6 +1136,74 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("does not treat empty-run loop status as successor evidence", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-empty-status",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-empty-status",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-empty-status",
+        run_id: "run-empty-status",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_INPUT",
+          active_run_ids: [],
+        },
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 12,
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 12 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "loop_status",
+      status: "WAITING_ON_INPUT",
+      activeRunIds: [],
+    });
+    coordinator.close();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -551,6 +551,136 @@ describe("remote turn terminal receipts", () => {
     expect(await next).toBeNull();
   });
 
+  test("does not apply late usage from a settled turn to its queued successor", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "first",
+        run_id: "run-first-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-first-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first-late-usage",
+        run_id: "run-first-late-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "result" });
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "second",
+        run_id: "run-second-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-second-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 111,
+      }),
+      runtime,
+    );
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-second-late-usage",
+        run_id: "run-second-late-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "second",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      result: "second",
+      runIds: ["run-second-late-usage"],
+    });
+    coordinator.close();
+  });
+
+  test("activates a queued turn from its terminal receipt", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first-terminal-only",
+        run_id: "run-first-terminal-only",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      runIds: ["run-first-terminal-only"],
+    });
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-second-terminal-only",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-second-terminal-only",
+        run_id: "run-second-terminal-only",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      runIds: ["run-second-terminal-only"],
+    });
+    expect(coordinator.hasInFlightTurn()).toBe(false);
+    coordinator.close();
+  });
+
   test("ignores a turn_finished receipt for a different active run", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -287,6 +287,13 @@ describe("remote turn terminal receipts", () => {
       runtime,
     );
     coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 1,
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
       {
         type: "turn_finished",
         runtime,
@@ -294,13 +301,6 @@ describe("remote turn terminal receipts", () => {
         run_id: "run-1",
         stop_reason: "end_turn",
       },
-      runtime,
-    );
-    coordinator.handleProtocolMessage(
-      streamDelta(runtime, {
-        message_type: "usage_statistics",
-        total_tokens: 1,
-      }),
       runtime,
     );
     expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
@@ -390,6 +390,16 @@ describe("remote turn terminal receipts", () => {
         total_tokens: 120,
         step_count: 3,
       }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-usage",
+        run_id: "run-usage",
+        stop_reason: "end_turn",
+      },
       runtime,
     );
 
@@ -504,7 +514,7 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
-  test("drops usage that arrives after the fallback result", async () => {
+  test("leaves usage after a completed result unassigned", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",
       onDeviceStatus: () => {},
@@ -546,9 +556,12 @@ describe("remote turn terminal receipts", () => {
       }),
       runtime,
     );
-    const next = coordinator.nextMessage();
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 12 },
+    });
+    expect(coordinator.hasInFlightTurn()).toBe(false);
     coordinator.close();
-    expect(await next).toBeNull();
   });
 
   test("does not apply late usage from a settled turn to its queued successor", async () => {
@@ -626,9 +639,99 @@ describe("remote turn terminal receipts", () => {
       content: "second",
     });
     expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 111 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
       type: "result",
       result: "second",
       runIds: ["run-second-late-usage"],
+    });
+    coordinator.close();
+  });
+
+  test("preserves the queued successor's usage when the prior turn emits none", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "first",
+        run_id: "run-first-no-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-first-no-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first-no-usage",
+        run_id: "run-first-no-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "result" });
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "second",
+        run_id: "run-second-with-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-second-with-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 222,
+      }),
+      runtime,
+    );
+    expect(coordinator.hasInFlightTurn()).toBe(true);
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-second-with-usage",
+        run_id: "run-second-with-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "second",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 222 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      result: "second",
+      runIds: ["run-second-with-usage"],
     });
     coordinator.close();
   });

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -829,6 +829,113 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("keeps global queue updates and trailing usage ahead of the result", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-queue-before-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-queue-before-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-queue-before-usage",
+        run_id: "run-queue-before-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_queue",
+        runtime,
+        queue: [],
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 12,
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "queue_update",
+      queue: [],
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 12 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+    });
+    coordinator.close();
+  });
+
+  test("keeps a canonical terminal successful when the transport closes during usage grace", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-close-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-close-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-close-during-grace",
+        run_id: "run-close-during-grace",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.closeWithError("socket closed");
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "finished",
+    });
+    expect(await coordinator.nextMessage()).toBeNull();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -1068,6 +1068,74 @@ describe("remote turn terminal receipts", () => {
     expect(await coordinator.nextMessage()).toBeNull();
   });
 
+  test("keeps same-turn loop status and usage ahead of the result", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-status-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-status-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-status-during-grace",
+        run_id: "run-status-during-grace",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_INPUT",
+          active_run_ids: ["run-status-during-grace"],
+        },
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 12,
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "loop_status",
+      status: "WAITING_ON_INPUT",
+      activeRunIds: ["run-status-during-grace"],
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 12 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+    });
+    coordinator.close();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -1204,6 +1204,62 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("does not treat stream ping as successor evidence", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-ping-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-ping-during-grace",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-ping-during-grace",
+        run_id: "run-ping-during-grace",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, { message_type: "ping" }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 12,
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "stream_event",
+      event: { message_type: "usage_statistics", total_tokens: 12 },
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+    });
+    coordinator.close();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -936,6 +936,138 @@ describe("remote turn terminal receipts", () => {
     expect(await coordinator.nextMessage()).toBeNull();
   });
 
+  test("defers successor errors and loop status during the prior turn's usage grace", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "first",
+        run_id: "run-first-before-error",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-first-before-error",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-first-before-error",
+        run_id: "run-first-before-error",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "error_message",
+        error: "second failed",
+        run_id: "run-second-error",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_INPUT",
+          active_run_ids: ["run-second-error"],
+        },
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      runIds: ["run-first-before-error"],
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "error",
+      runId: "run-second-error",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: false,
+      runIds: ["run-second-error"],
+    });
+    coordinator.close();
+  });
+
+  test("drains deferred canonical terminals before transport close", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.trackSentTurn(runtime);
+    for (const [ordinal, runId] of [
+      ["first", "run-first-before-close"],
+      ["second", "run-second-before-close"],
+    ] as const) {
+      coordinator.handleProtocolMessage(
+        streamDelta(runtime, {
+          message_type: "assistant_message",
+          content: ordinal,
+          run_id: runId,
+        }),
+        runtime,
+      );
+      coordinator.handleProtocolMessage(
+        streamDelta(runtime, {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+          run_id: runId,
+        }),
+        runtime,
+      );
+      coordinator.handleProtocolMessage(
+        {
+          type: "turn_finished",
+          runtime,
+          turn_id: `turn-${ordinal}-before-close`,
+          run_id: runId,
+          stop_reason: "end_turn",
+        },
+        runtime,
+      );
+    }
+    coordinator.closeWithError("socket closed");
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "first",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      runIds: ["run-first-before-close"],
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "second",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      runIds: ["run-second-before-close"],
+    });
+    expect(await coordinator.nextMessage()).toBeNull();
+  });
+
   test("activates a queued turn from its terminal receipt", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -413,6 +413,144 @@ describe("remote turn terminal receipts", () => {
     coordinator.close();
   });
 
+  test("settles after turn_finished when trailing usage never arrives", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "done without usage",
+        run_id: "run-no-usage",
+        id: "message-no-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-no-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-no-usage",
+        run_id: "run-no-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      content: "done without usage",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "done without usage",
+      runIds: ["run-no-usage"],
+    });
+    expect(coordinator.hasInFlightTurn()).toBe(false);
+    coordinator.close();
+  });
+
+  test("does not let the request timeout override a canonical terminal", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      requestTimeoutMs: 5,
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-short-timeout",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-short-timeout",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-short-timeout",
+        run_id: "run-short-timeout",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "result",
+      success: true,
+      result: "finished",
+    });
+    coordinator.close();
+  });
+
+  test("drops usage that arrives after the fallback result", async () => {
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "assistant_message",
+        content: "finished",
+        run_id: "run-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+        run_id: "run-late-usage",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      {
+        type: "turn_finished",
+        runtime,
+        turn_id: "turn-late-usage",
+        run_id: "run-late-usage",
+        stop_reason: "end_turn",
+      },
+      runtime,
+    );
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "assistant" });
+    expect(await coordinator.nextMessage()).toMatchObject({ type: "result" });
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        message_type: "usage_statistics",
+        total_tokens: 12,
+      }),
+      runtime,
+    );
+    const next = coordinator.nextMessage();
+    coordinator.close();
+    expect(await next).toBeNull();
+  });
+
   test("ignores a turn_finished receipt for a different active run", async () => {
     const coordinator = new RemoteTurnCoordinator({
       label: "test",


### PR DESCRIPTION
## tl;dr

A completed App Server turn could leave `sendAndWaitForResult()` waiting forever when the stream emitted `stop_reason` and `turn_finished` but omitted the optional trailing `usage_statistics` frame.

This change treats a correlated `turn_finished` receipt as canonical completion. It preserves a short window for hosted usage to arrive first, then emits the result even when usage never arrives. Late terminal metadata cannot activate or contaminate the next queued turn.

## Before and after

```text
Before

1. assistant_message
2. stop_reason
3. turn_finished
4. No usage_statistics arrives
5. The SDK waits forever for a terminal result
```

```text
After

1. assistant_message
2. stop_reason
3. turn_finished
4. The SDK briefly waits for optional usage_statistics
5. usage_statistics arrives → usage remains ahead of result
   or no usage arrives → result is emitted after the grace period
```

Once `turn_finished` arrives, the normal request timeout is cleared so it cannot replace a successful terminal receipt with a timeout failure.

## Testing

The red-first regression tests reproduce the reported App Server wire sequence with the real session and turn-coordinator logic; only WebSocket delivery is replaced with the existing in-memory fake. Applied as test-only changes to exact base commit `fa0e2bc`, both the coordinator test and SDK result-only test timed out at 500 ms. The identical tests pass with this change in approximately 100 ms.

The tests also cover the request-timeout race and terminal usage arriving after the fallback result. Live integration tests were not run because the bug requires a deliberately incomplete terminal sequence that the current live service does not deterministically emit.

## Breadcrumbs

- Requested in: #300
- Letta conversation: [`conv-f7390293-9d28-4f40-b2a8-2a2bd5b7fab4`](https://chat.letta.com/chat/agent-ec05a4e0-f50c-47fd-8e7b-960f081ab42e?conversation=conv-f7390293-9d28-4f40-b2a8-2a2bd5b7fab4)
- Origin: Introduced by #293, which deferred terminal results until hosted `usage_statistics` arrives but left no completion path when that frame is absent.
- Root-cause evidence: #300 reports `assistant_message → stop_reason → turn_finished` with no later `usage_statistics`; the test-only patch reproduces the hang on `fa0e2bc`.
