### PR TITLE
docs: explain archived conversation recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ await session.send(message);
 measures the tracked turn and excludes session initialization; measure `ready()`
 separately when startup latency matters.
 
+## Recover an archived conversation
+
+Archiving does not delete a conversation. Use the management API to include
+archived conversations in a listing, restore the intended conversation, and
+then resume it by ID:
+
+```typescript
+const archived = await client.conversations.list({
+  archiveStatus: "archived",
+  summarySearch: "project handoff", // Optional: narrow the listing.
+});
+
+const conversation = archived.find(({ summary }) =>
+  summary?.includes("project handoff")
+);
+if (!conversation) throw new Error("Archived conversation not found");
+
+await client.conversations.update(conversation.id, { archived: false });
+
+await using session = client.resumeSession(conversation.id);
+await session.send("Continue where we left off.");
+```
+
+The same `client.conversations` management surface is available for Cloud and
+App Server backends; no separate recovery API is required.
+
 For a simple question that should not create or use an agent, call `query()`.
 It creates an agent-free ephemeral conversation from the supplied model and
 system prompt, streams the turn, and closes the runtime when iteration ends:

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -63,6 +63,7 @@ export interface ListConversationsOptions {
   limit?: Present<ConversationListParams["limit"]>;
   order?: Present<ConversationListParams["order"]>;
   orderBy?: "createdAt" | "lastRunCompletion" | "lastMessageAt";
+  /** Filter by archive state. Use `"archived"` to find conversations to restore. */
   archiveStatus?: Present<ConversationListParams["archive_status"]>;
   summarySearch?: Present<ConversationListParams["summary_search"]>;
 }
@@ -83,6 +84,7 @@ export interface UpdateConversationOptions {
   model?: ConversationUpdateParams["model"];
   modelSettings?: ConversationUpdateParams["model_settings"];
   contextWindowLimit?: ConversationUpdateParams["context_window_limit"];
+  /** Set to `false` to restore an archived conversation. */
   archived?: ConversationUpdateParams["archived"];
 }
 
@@ -204,11 +206,13 @@ export interface ModelsClient {
 }
 
 export interface ConversationsClient {
+  /** List conversations, including archived ones when selected by `archiveStatus`. */
   list(
     options?: ListConversationsOptions,
   ): Promise<LettaConversation[]>;
   retrieve(conversationId: string): Promise<LettaConversation>;
   create(options: CreateConversationOptions): Promise<LettaConversation>;
+  /** Update conversation metadata or restore it with `{ archived: false }`. */
   update(
     conversationId: string,
     options: UpdateConversationOptions,

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -362,6 +362,73 @@ async function exerciseManagementApi(
 }
 
 describe("portable management namespaces", () => {
+  test("lists and restores archived conversations over Cloud", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    await expect(
+      client.conversations.list({ archiveStatus: "archived" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      client.conversations.update("conv-1", { archived: false }),
+    ).resolves.toMatchObject({ id: "conv-1", archived: false });
+
+    expect(requests.map(({ url, method, body }) => ({
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      method,
+      body,
+    }))).toEqual([
+      {
+        path: "/v1/conversations/",
+        query: { archive_status: "archived" },
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/conversations/conv-1",
+        query: {},
+        method: "PATCH",
+        body: { archived: false },
+      },
+    ]);
+  });
+
+  test("lists and restores archived conversations over the App Server", async () => {
+    ManagementSocket.instances = [];
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      WebSocket: ManagementSocket,
+    });
+
+    await expect(
+      client.conversations.list({ archiveStatus: "archived" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      client.conversations.update("conv-1", { archived: false }),
+    ).resolves.toMatchObject({ id: "conv-1", archived: false });
+
+    expect(
+      ManagementSocket.instances.flatMap((socket) => socket.sent),
+    ).toEqual([
+      expect.objectContaining({
+        type: "conversation_list",
+        query: { archive_status: "archived" },
+      }),
+      expect.objectContaining({
+        type: "conversation_update",
+        conversation_id: "conv-1",
+        body: { archived: false },
+      }),
+    ]);
+  });
+
   test("forks through a selected message and archives the fork over Cloud", async () => {
     const requests: RecordedRequest[] = [];
     const client = new PortableLettaAgentClient({


### PR DESCRIPTION
## Summary
- document how to list, restore, and resume an accidentally archived conversation using the existing management API
- add API-reference comments for archive filtering and restoration
- verify archived listing and unarchive payloads across Cloud REST and the shared App Server transport

This addresses a generic support report that the existing recovery path was not discoverable. No duplicate API is introduced.

## Test plan
- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)

Linear: https://linear.app/letta/issue/LET-11923/document-archived-conversation-recovery-in-the-agent-sdk