### PR TITLE
fix: dispose client-owned management resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install @letta-ai/letta-agent-sdk
 ```typescript
 import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
-const client = new LettaAgentClient({ backend: "cloud" });
+await using client = new LettaAgentClient({ backend: "cloud" });
 
 // Create the agent once...
 const agentId = await client.createAgent({
@@ -31,6 +31,10 @@ for await (const message of session.stream()) {
   if (message.type === "assistant") process.stdout.write(message.content);
 }
 ```
+
+Client disposal closes its pooled management connection and any local App
+Server started for management calls. Sessions are independently owned and must
+still be closed or disposed separately.
 
 Latency-sensitive applications can initialize the runtime and transport before
 the first user action without fetching transcript history or invoking the model:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install @letta-ai/letta-agent-sdk
 ```typescript
 import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
-await using client = new LettaAgentClient({ backend: "cloud" });
+const client = new LettaAgentClient({ backend: "cloud" });
 
 // Create the agent once...
 const agentId = await client.createAgent({
@@ -32,9 +32,10 @@ for await (const message of session.stream()) {
 }
 ```
 
-Client disposal closes its pooled management connection and any local App
-Server started for management calls. Sessions are independently owned and must
-still be closed or disposed separately.
+Local and remote management clients can use `await using client = new
+LettaAgentClient(...)`, or call `await client.close()` explicitly. Client
+disposal closes its pooled management connection and any local App Server it
+started. Sessions are independently owned and must still be closed separately.
 
 Latency-sensitive applications can initialize the runtime and transport before
 the first user action without fetching transcript history or invoking the model:

--- a/examples/custom-tools/README.md
+++ b/examples/custom-tools/README.md
@@ -51,8 +51,8 @@ const myTool: AnyAgentTool = {
   },
 };
 
-const client = new LettaAgentClient({ backend: "cloud" });
-const session = client.resumeSession(agentId, {
+await using client = new LettaAgentClient({ backend: "cloud" });
+await using session = client.resumeSession(agentId, {
   tools: [myTool],
 });
 ```

--- a/examples/custom-tools/README.md
+++ b/examples/custom-tools/README.md
@@ -51,7 +51,7 @@ const myTool: AnyAgentTool = {
   },
 };
 
-await using client = new LettaAgentClient({ backend: "cloud" });
+const client = new LettaAgentClient({ backend: "cloud" });
 await using session = client.resumeSession(agentId, {
   tools: [myTool],
 });

--- a/examples/custom-tools/main.ts
+++ b/examples/custom-tools/main.ts
@@ -109,7 +109,7 @@ async function main() {
     throw new Error("Set LETTA_API_KEY to run the Cloud custom-tools example.");
   }
 
-  const client = new LettaAgentClient({
+  await using client = new LettaAgentClient({
     backend: "cloud",
     apiKey: process.env.LETTA_API_KEY,
   });

--- a/examples/custom-tools/main.ts
+++ b/examples/custom-tools/main.ts
@@ -109,7 +109,7 @@ async function main() {
     throw new Error("Set LETTA_API_KEY to run the Cloud custom-tools example.");
   }
 
-  await using client = new LettaAgentClient({
+  const client = new LettaAgentClient({
     backend: "cloud",
     apiKey: process.env.LETTA_API_KEY,
   });

--- a/examples/economics-seminar/README.md
+++ b/examples/economics-seminar/README.md
@@ -117,10 +117,12 @@ After running a seminar, the agents can be "teleported" into other contexts:
 ```typescript
 import { LettaAgentClient } from '@letta-ai/letta-agent-sdk';
 
-const client = new LettaAgentClient({ backend: 'local' });
+await using client = new LettaAgentClient({ backend: 'local' });
 
 // Get agent ID from --status
-const drChen = client.resumeSession('agent-xxx', { permissionMode: 'unrestricted' });
+await using drChen = client.resumeSession('agent-xxx', {
+  permissionMode: 'unrestricted',
+});
 
 // Dr. Chen remembers all past seminars!
 await drChen.send('What patterns have you noticed in economics presentations?');

--- a/examples/research-team/README.md
+++ b/examples/research-team/README.md
@@ -91,8 +91,8 @@ The underlying SDK operation is an ordinary resume:
 ```typescript
 import { LettaAgentClient } from '@letta-ai/letta-agent-sdk';
 
-const client = new LettaAgentClient({ backend: 'local' });
-const researcher = client.resumeSession('agent-xxx', {
+await using client = new LettaAgentClient({ backend: 'local' });
+await using researcher = client.resumeSession('agent-xxx', {
   allowedTools: ['Read', 'Write'],
   permissionMode: 'unrestricted',
 });

--- a/examples/research-team/teleport-example.ts
+++ b/examples/research-team/teleport-example.ts
@@ -130,7 +130,7 @@ async function main() {
   console.log('   // In your own code:');
   console.log('   import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";');
   console.log('   await using client = new LettaAgentClient({ backend: "local" });');
-  console.log(`   const agent = client.resumeSession("${teamState.agentIds.researcher}");`);
+  console.log(`   await using agent = client.resumeSession("${teamState.agentIds.researcher}");`);
   console.log('   await agent.send("Your question here");');
   console.log('');
 }

--- a/examples/research-team/teleport-example.ts
+++ b/examples/research-team/teleport-example.ts
@@ -129,7 +129,7 @@ async function main() {
   console.log('Try it yourself:\n');
   console.log('   // In your own code:');
   console.log('   import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";');
-  console.log('   const client = new LettaAgentClient({ backend: "local" });');
+  console.log('   await using client = new LettaAgentClient({ backend: "local" });');
   console.log(`   const agent = client.resumeSession("${teamState.agentIds.researcher}");`);
   console.log('   await agent.send("Your question here");');
   console.log('');

--- a/examples/sdk-tour.ts
+++ b/examples/sdk-tour.ts
@@ -12,7 +12,7 @@
 
 import { LettaAgentClient } from '../src/index.js';
 
-const client = new LettaAgentClient({ backend: 'local' });
+await using client = new LettaAgentClient({ backend: 'local' });
 
 async function main() {
   const example = process.argv[2] || 'basic';
@@ -721,4 +721,4 @@ async function testConversations() {
   console.log();
 }
 
-main().catch(console.error);
+await main().catch(console.error);

--- a/examples/stateless-conversations/README.md
+++ b/examples/stateless-conversations/README.md
@@ -28,7 +28,7 @@ stored by Letta Cloud, while the App Server executes on your machine.
 ```typescript
 import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
-const client = new LettaAgentClient({
+await using client = new LettaAgentClient({
   backend: "local",
   appServer: { harnessBackend: "api" },
 });

--- a/examples/stateless-conversations/main.ts
+++ b/examples/stateless-conversations/main.ts
@@ -18,7 +18,7 @@ if (!process.env.LETTA_API_KEY) {
   throw new Error("Set LETTA_API_KEY to run the stateless conversation examples.");
 }
 
-const client = new LettaAgentClient({
+await using client = new LettaAgentClient({
   backend: "local",
   appServer: {
     harnessBackend: "api",

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -51,6 +51,7 @@ type ActiveConnection = {
   client: AppServerClient;
   ownedConnection: OwnedConnection | null;
   detachDisconnect: () => void;
+  closePromise: Promise<void> | null;
 };
 
 function ensureResponse<T>(
@@ -76,8 +77,35 @@ export class AppServerManagementTransport
 {
   private connectionPromise: Promise<ActiveConnection> | null = null;
   private closingConnections = new Set<Promise<void>>();
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(private readonly options: AppServerManagementOptions) {}
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    const connectionPromise = this.connectionPromise;
+    this.connectionPromise = null;
+    const close = (async () => {
+      if (connectionPromise) {
+        let connection: ActiveConnection | null = null;
+        try {
+          connection = await connectionPromise;
+        } catch {
+          // Connection startup already owns cleanup on failure.
+        }
+        if (connection) {
+          await this.trackClosingConnection(connection);
+        }
+      }
+      if (this.closingConnections.size > 0) {
+        await Promise.all([...this.closingConnections]);
+      }
+    })();
+    this.closePromise = close;
+    return close;
+  }
 
   async listAgents(query: AgentListParams): Promise<LettaAgent[]> {
     const response = await this.request<AgentListResponseMessage>(
@@ -255,9 +283,11 @@ export class AppServerManagementTransport
     body: Record<string, unknown>,
     responseType: string,
   ): Promise<TResponse> {
+    this.assertOpen();
     if (this.closingConnections.size > 0) {
       await Promise.all([...this.closingConnections]);
     }
+    this.assertOpen();
     // Concurrent requests share the same connect promise and request-id
     // counter, while connection identity keeps this pool independent from
     // session clients using the same app-server.
@@ -279,6 +309,7 @@ export class AppServerManagementTransport
   }
 
   private acquireConnection(): Promise<ActiveConnection> {
+    this.assertOpen();
     if (this.connectionPromise) return this.connectionPromise;
     const promise: Promise<ActiveConnection> = this.openConnection().then(
       (connection) => {
@@ -287,6 +318,10 @@ export class AppServerManagementTransport
         connection.detachDisconnect = connection.client.onDisconnect(() => {
           this.discardConnection(promise, connection);
         });
+        if (this.closed) {
+          void this.trackClosingConnection(connection);
+          throw new Error("Management transport is closed");
+        }
         return connection;
       },
       (error) => {
@@ -344,7 +379,12 @@ export class AppServerManagementTransport
       client,
       ownedConnection,
       detachDisconnect: () => {},
+      closePromise: null,
     };
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error("Management transport is closed");
   }
 
   private discardConnection(
@@ -371,7 +411,12 @@ export class AppServerManagementTransport
 }
 
 async function closeConnection(connection: ActiveConnection): Promise<void> {
-  connection.detachDisconnect();
-  connection.client.close();
-  connection.ownedConnection?.close();
+  if (connection.closePromise) return connection.closePromise;
+  const close = Promise.resolve().then(() => {
+    connection.detachDisconnect();
+    connection.client.close();
+    connection.ownedConnection?.close();
+  });
+  connection.closePromise = close;
+  return close;
 }

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -637,7 +637,10 @@ export class LettaAgentClientBase implements AsyncDisposable {
     if (this.backend !== "cloud") {
       throw new Error('client.computers is only available with backend: "cloud".');
     }
-    this.computersClient ??= new ComputersClientImpl(this.getCloudClient());
+    this.computersClient ??= new ComputersClientImpl(
+      this.getCloudClient(),
+      () => this.assertOpen(),
+    );
     return this.computersClient;
   }
 
@@ -648,6 +651,7 @@ export class LettaAgentClientBase implements AsyncDisposable {
     this.repositoriesClient ??= new RepositoriesClient(
       this.cloudOptions(),
       this.getCloudClient(),
+      () => this.assertOpen(),
     );
     return this.repositoriesClient;
   }

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -136,7 +136,7 @@ type OneShotSession = LettaCodeSession & {
  * `cloud` uses agents hosted on Letta Cloud, with an explicit remote
  * environment or SDK-managed sandbox.
  */
-export class LettaAgentClientBase {
+export class LettaAgentClientBase implements AsyncDisposable {
   readonly backend: LettaCodeBackend;
   readonly computer: ComputerSelector | undefined;
   /** @deprecated Use `computer`. */
@@ -150,6 +150,8 @@ export class LettaAgentClientBase {
   private agentRepositoriesClient: AgentRepositoriesClient | null = null;
   private cloudClient: Letta | null = null;
   private managementTransport: ManagementTransport | null = null;
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(options: LettaCodeClientOptions = {}) {
     const backend = options.backend ?? "local";
@@ -239,15 +241,18 @@ export class LettaAgentClientBase {
    * it belongs to the client/session execution context.
    */
   get repositories(): RepositoriesClient {
+    this.assertOpen();
     return this.getRepositoriesClient();
   }
 
   /** Discover and resolve computers registered with this Letta Cloud account. */
   get computers(): ComputersClient {
+    this.assertOpen();
     return this.getComputersClient();
   }
 
   async createAgent(options: CreateAgentOptions = {}): Promise<string> {
+    this.assertOpen();
     if (hasCreateAgentEnvironment(options)) {
       throw new Error(
         "createAgent() does not accept environment. Set a client default or pass environment to resumeSession()/createSession().",
@@ -299,6 +304,7 @@ export class LettaAgentClientBase {
     agentId: string,
     options: LettaCodeClientSessionOptions = {},
   ): LettaCodeSession {
+    this.assertOpen();
     if (typeof agentId !== "string" || agentId.length === 0) {
       throw new Error("createSession() requires a non-empty agent id.");
     }
@@ -339,6 +345,7 @@ export class LettaAgentClientBase {
     id: string,
     options: LettaCodeClientSessionOptions = {},
   ): LettaCodeSession {
+    this.assertOpen();
     const sessionOptions = stripCloudExecutionOptions(options);
     validateCreateSessionOptions(sessionOptions);
     this.assertSessionBackend("resumeSession", options);
@@ -393,6 +400,7 @@ export class LettaAgentClientBase {
     agentId: string,
     options: LettaCodeClientSessionOptions = {},
   ): Promise<SDKResultMessage> {
+    this.assertOpen();
     const session = this.createSession(agentId, options);
 
     try {
@@ -404,6 +412,7 @@ export class LettaAgentClientBase {
 
   /** Run one prompt in a new agent-free ephemeral conversation. */
   query(params: QueryParams): Query {
+    this.assertOpen();
     validateAgentFreeQueryOptions(params.options);
     return createQuery((options) => this.createAgentFreeSession(options), params);
   }
@@ -411,6 +420,7 @@ export class LettaAgentClientBase {
   private async createAgentFreeSession(
     options: AgentFreeQueryOptions,
   ): Promise<LettaCodeSession> {
+    this.assertOpen();
     validateAgentFreeQueryOptions(options);
     const sessionOptions = agentFreeSessionOptions(options);
     this.assertSessionBackend("query", sessionOptions);
@@ -671,6 +681,7 @@ export class LettaAgentClientBase {
   }
 
   private getManagementTransport(): ManagementTransport {
+    this.assertOpen();
     if (this.managementTransport) return this.managementTransport;
     if (this.backend === "remote") {
       this.managementTransport = new AppServerManagementTransport(
@@ -684,6 +695,30 @@ export class LettaAgentClientBase {
       this.managementTransport = this.createLocalManagementTransport();
     }
     return this.managementTransport;
+  }
+
+  /**
+   * Release resources owned directly by this client, including its pooled
+   * management connection and any local App Server started for that pool.
+   * Sessions have independent lifecycles and must be closed separately.
+   */
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    const transport = this.managementTransport;
+    this.managementTransport = null;
+    const close = transport?.close() ?? Promise.resolve();
+    this.closePromise = close;
+    return close;
+  }
+
+  /** Async-disposal alias for close(). */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error("LettaAgentClient is closed");
   }
 
   private cloudOptions(): LettaCodeCloudClientOptions {

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -120,6 +120,10 @@ function toOrderRelativeCursors(query: MessageListParams): MessageListParams {
 export class CloudManagementTransport implements ManagementTransport {
   constructor(private readonly client: Letta) {}
 
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
   async listAgents(query: AgentListParams): Promise<LettaAgent[]> {
     const page = await this.client.agents.list(query);
     return page.items;

--- a/src/computers.ts
+++ b/src/computers.ts
@@ -95,13 +95,17 @@ function toComputer(environment: RemoteEnvironmentConnection): Computer {
 export class ComputersClientImpl implements ComputersClient {
   private readonly environments: RemoteEnvironmentClient;
 
-  constructor(client: Letta) {
+  constructor(
+    client: Letta,
+    private readonly assertOpen: () => void = () => {},
+  ) {
     this.environments = new RemoteEnvironmentClient({}, client);
   }
 
   async list(
     options: ListComputersOptions = {},
   ): Promise<ListComputersResult> {
+    this.assertOpen();
     const result = await this.environments.listEnvironments(options);
     return {
       computers: result.connections.map(toComputer),
@@ -110,6 +114,7 @@ export class ComputersClientImpl implements ComputersClient {
   }
 
   async get(deviceId: string): Promise<Computer> {
+    this.assertOpen();
     if (typeof deviceId !== "string" || deviceId.trim().length === 0) {
       throw new Error("Invalid deviceId. Expected a non-empty string.");
     }
@@ -119,6 +124,7 @@ export class ComputersClientImpl implements ComputersClient {
   }
 
   async resolve(selector: ComputerSelector): Promise<ResolvedComputer> {
+    this.assertOpen();
     const result = await this.environments.resolveEnvironment(
       selectorToRemoteTarget(selector),
     );

--- a/src/management.ts
+++ b/src/management.ts
@@ -30,6 +30,7 @@ import type {
 import type { ListModelsResult, SendMessage } from "./types.js";
 
 export interface ManagementTransport {
+  close(): Promise<void>;
   listAgents(query: AgentListParams): Promise<LettaAgent[]>;
   retrieveAgent(agentId: string): Promise<LettaAgent>;
   updateAgent(

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -61,6 +61,7 @@ export class RepositoriesClient {
   constructor(
     options: LettaCodeCloudClientOptions,
     private readonly client: Letta = createCloudClient(options),
+    private readonly assertOpen: () => void = () => {},
   ) {}
 
   async create(params: CreateRepositoryParams): Promise<Repository> {
@@ -252,6 +253,7 @@ export class RepositoriesClient {
     method: string,
     body: unknown,
   ): Promise<unknown> {
+    this.assertOpen();
     const options = body !== undefined ? { body } : undefined;
     switch (method) {
       case "GET":

--- a/src/tests/client-lifecycle-process.test.ts
+++ b/src/tests/client-lifecycle-process.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 describe("LettaAgentClient process lifecycle", () => {
-  test("an async-disposed management-only client lets the process exit", async () => {
+  test("async disposal exits without leaving the owned App Server alive", async () => {
     const fixture = new URL(
       "./fixtures/client-management-exit.ts",
       import.meta.url,
@@ -13,9 +13,22 @@ describe("LettaAgentClient process lifecycle", () => {
     });
     const timeout = setTimeout(() => child.kill(), 20_000);
     timeout.unref?.();
+    const stdoutPromise = new Response(child.stdout).text();
+    let appServerPid: number | null = null;
+    for (let attempt = 0; attempt < 100 && appServerPid === null; attempt += 1) {
+      const lookup = Bun.spawn(["pgrep", "-P", String(child.pid)], {
+        stdout: "pipe",
+        stderr: "ignore",
+      });
+      const output = await new Response(lookup.stdout).text();
+      await lookup.exited;
+      const pid = Number.parseInt(output.trim().split("\n")[0] ?? "", 10);
+      if (Number.isInteger(pid)) appServerPid = pid;
+      else await Bun.sleep(25);
+    }
     const [exitCode, stdout, stderr] = await Promise.all([
       child.exited,
-      new Response(child.stdout).text(),
+      stdoutPromise,
       new Response(child.stderr).text(),
     ]);
     clearTimeout(timeout);
@@ -23,6 +36,8 @@ describe("LettaAgentClient process lifecycle", () => {
     if (exitCode !== 0) {
       throw new Error(`Fixture exited with ${exitCode}. stderr:\n${stderr}`);
     }
+    expect(appServerPid).not.toBeNull();
+    expect(() => process.kill(appServerPid!, 0)).toThrow();
     expect(stdout).toContain("CALL_COMPLETE");
     expect(exitCode).toBe(0);
   }, 25_000);

--- a/src/tests/client-lifecycle-process.test.ts
+++ b/src/tests/client-lifecycle-process.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+describe("LettaAgentClient process lifecycle", () => {
+  test("an async-disposed management-only client lets the process exit", async () => {
+    const fixture = new URL(
+      "./fixtures/client-management-exit.ts",
+      import.meta.url,
+    );
+    const child = Bun.spawn([process.execPath, fixture.pathname], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timeout = setTimeout(() => child.kill(), 20_000);
+    timeout.unref?.();
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    clearTimeout(timeout);
+
+    if (exitCode !== 0) {
+      throw new Error(`Fixture exited with ${exitCode}. stderr:\n${stderr}`);
+    }
+    expect(stdout).toContain("CALL_COMPLETE");
+    expect(exitCode).toBe(0);
+  }, 25_000);
+});

--- a/src/tests/computers.test.ts
+++ b/src/tests/computers.test.ts
@@ -45,6 +45,22 @@ function cloudClient(fetchMock: typeof fetch): LettaAgentClient {
 }
 
 describe("client.computers", () => {
+  test("a pre-obtained namespace rejects requests after client close", async () => {
+    let calls = 0;
+    const client = cloudClient(
+      createFetchMock(() => {
+        calls += 1;
+        return jsonResponse({ connections: [], hasNextPage: false });
+      }),
+    );
+    const computers = client.computers;
+
+    await client.close();
+
+    await expect(computers.list()).rejects.toThrow("LettaAgentClient is closed");
+    expect(calls).toBe(0);
+  });
+
   test("lists computers with filters and normalizes product-facing fields", async () => {
     const requests: URL[] = [];
     const client = cloudClient(

--- a/src/tests/fixtures/client-management-exit.ts
+++ b/src/tests/fixtures/client-management-exit.ts
@@ -11,3 +11,4 @@ await using client = new LettaAgentClient({
 const models = await client.models.list();
 console.log(`MODELS=${models.entries.length}`);
 console.log("CALL_COMPLETE");
+await Bun.sleep(500);

--- a/src/tests/fixtures/client-management-exit.ts
+++ b/src/tests/fixtures/client-management-exit.ts
@@ -1,0 +1,13 @@
+import { LettaAgentClient } from "../../index.js";
+
+await using client = new LettaAgentClient({
+  backend: "local",
+  appServer: {
+    harnessBackend: "local",
+    startupTimeoutMs: 15_000,
+  },
+});
+
+const models = await client.models.list();
+console.log(`MODELS=${models.entries.length}`);
+console.log("CALL_COMPLETE");

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -1167,6 +1167,18 @@ class MultiClientAppServerSocket extends ManagementSocket {
   }
 }
 
+class DeferredConnectManagementSocket extends ManagementSocket {
+  static pending: DeferredConnectManagementSocket[] = [];
+
+  protected override handleConnect(): void {
+    DeferredConnectManagementSocket.pending.push(this);
+  }
+
+  open(): void {
+    super.handleConnect();
+  }
+}
+
 describe("app-server management connection lifecycle", () => {
   const url = "ws://remote.test/ws";
 
@@ -1175,6 +1187,141 @@ describe("app-server management connection lifecycle", () => {
       (socket) => socket.readyState !== 3,
     );
   }
+
+  test("closes the pooled socket and SDK-owned App Server", async () => {
+    ManagementSocket.instances = [];
+    let ownedCloseCount = 0;
+    const transport = new AppServerManagementTransport({
+      connect: async () => ({
+        url,
+        close: () => {
+          ownedCloseCount += 1;
+        },
+      }),
+      WebSocket: ManagementSocket,
+    });
+
+    await transport.listAgents({});
+    expect(openSockets()).toHaveLength(1);
+
+    await transport.close();
+    expect(openSockets()).toHaveLength(0);
+    expect(ownedCloseCount).toBe(1);
+
+    await transport.close();
+    expect(ownedCloseCount).toBe(1);
+  });
+
+  test("closing before first use does not start an App Server", async () => {
+    let connectCount = 0;
+    const transport = new AppServerManagementTransport({
+      connect: async () => {
+        connectCount += 1;
+        return { url, close: () => {} };
+      },
+      WebSocket: ManagementSocket,
+    });
+
+    await transport.close();
+    expect(connectCount).toBe(0);
+    await expect(transport.listAgents({})).rejects.toThrow(
+      "Management transport is closed",
+    );
+  });
+
+  test("closing during startup cleans up the connection once it opens", async () => {
+    ManagementSocket.instances = [];
+    DeferredConnectManagementSocket.pending = [];
+    let ownedCloseCount = 0;
+    const transport = new AppServerManagementTransport({
+      connect: async () => ({
+        url,
+        close: () => {
+          ownedCloseCount += 1;
+        },
+      }),
+      WebSocket: DeferredConnectManagementSocket,
+    });
+
+    const request = transport.listAgents({});
+    while (DeferredConnectManagementSocket.pending.length === 0) {
+      await Bun.sleep(1);
+    }
+    const close = transport.close();
+    DeferredConnectManagementSocket.pending[0]?.open();
+
+    await expect(request).rejects.toThrow("Management transport is closed");
+    await close;
+    expect(ownedCloseCount).toBe(1);
+    expect(openSockets()).toHaveLength(0);
+  });
+
+  test("closing rejects an active request and cleans up once", async () => {
+    MultiClientAppServerSocket.reset();
+    MultiClientAppServerSocket.agentListResponseDelayMs = 100;
+    let ownedCloseCount = 0;
+    const transport = new AppServerManagementTransport({
+      connect: async () => ({
+        url,
+        close: () => {
+          ownedCloseCount += 1;
+        },
+      }),
+      WebSocket: MultiClientAppServerSocket,
+    });
+
+    const request = transport.listAgents({});
+    while (MultiClientAppServerSocket.agentListRequests === 0) {
+      await Bun.sleep(1);
+    }
+    await transport.close();
+
+    await expect(request).rejects.toThrow("App-server client closed");
+    expect(ownedCloseCount).toBe(1);
+    expect(openSockets()).toHaveLength(0);
+  });
+
+  test("client close releases management without closing an independent session", async () => {
+    MultiClientAppServerSocket.reset();
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: MultiClientAppServerSocket,
+    });
+
+    await client.agents.list();
+    const managementSockets = new Set(ManagementSocket.instances);
+    const session = client.resumeSession("conv-1");
+    await asAdvanced(session).initialize();
+    const sessionSockets = ManagementSocket.instances.filter(
+      (socket) => !managementSockets.has(socket),
+    );
+    expect(sessionSockets.length).toBeGreaterThan(0);
+
+    await client.close();
+    expect(sessionSockets.every((socket) => socket.readyState === 1)).toBe(true);
+    expect(() => client.agents.list()).toThrow(
+      "LettaAgentClient is closed",
+    );
+
+    session.close();
+  });
+
+  test("a lazy query cannot create a session after client close", async () => {
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: ManagementSocket,
+    });
+    const query = client.query({
+      prompt: "hello",
+      options: { model: "test/model", system: "Be concise." },
+    });
+
+    await client.close();
+
+    await expect(query.next()).rejects.toThrow("LettaAgentClient is closed");
+  });
 
   test("keeps the management connection pooled while idle", async () => {
     ManagementSocket.instances = [];

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { LettaAgentClient } from "../client.js";
 import type { LettaCodeSession } from "../types.js";
 
 type AssertTrue<T extends true> = T;
@@ -24,6 +25,11 @@ type _HasClose = AssertTrue<HasKey<"close">>;
 type _NoInitialize = AssertFalse<HasKey<"initialize">>;
 type _NoRunTurn = AssertFalse<HasKey<"runTurn">>;
 type _NoUpdateToolset = AssertFalse<HasKey<"updateToolset">>;
+
+type HasClientKey<K extends PropertyKey> =
+  K extends keyof LettaAgentClient ? true : false;
+type _ClientHasClose = AssertTrue<HasClientKey<"close">>;
+type _ClientHasAsyncDispose = AssertTrue<HasClientKey<typeof Symbol.asyncDispose>>;
 
 describe("public LettaCodeSession type", () => {
   test("keeps the canonical public session surface", () => {

--- a/src/tests/repositories.test.ts
+++ b/src/tests/repositories.test.ts
@@ -41,6 +41,19 @@ function cloudClient(fetchMock: typeof fetch): LettaAgentClient {
 }
 
 describe("RepositoriesClient.delete", () => {
+  test("a pre-obtained namespace rejects requests after client close", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () => jsonResponse({ repositories: [] })),
+    );
+    const repositories = client.repositories;
+
+    await client.close();
+
+    await expect(repositories.list()).rejects.toThrow("LettaAgentClient is closed");
+    expect(requests).toHaveLength(0);
+  });
+
   test("issues DELETE /v1/repositories/:id and resolves on success", async () => {
     const requests: RecordedRequest[] = [];
     const client = cloudClient(


### PR DESCRIPTION
## tl;dr

Management-only local clients keep a pooled WebSocket and an SDK-owned App Server alive after the request finishes. Callers can now use `await client.close()` or `await using client = new LettaAgentClient(...)` to release those resources deterministically.

Client disposal is idempotent, handles connection and request races, and prevents later client operations from creating new resources. Sessions keep their independent lifecycle and must still be closed separately.

## Before and after

A real local management script previously reached:

```text
MODELS=2078
CALL_COMPLETE
```

but remained alive until a 12-second external timeout because the client exposed no cleanup method.

The regression fixture now runs the actual local App Server through `client.models.list()` inside `await using`. Disposal closes the pooled WebSocket and SDK-owned child, and the process exits naturally with code 0. The test records the real child PID and verifies that PID is no longer alive after the caller exits.

## Review notes

The main risk is disposal racing connection startup, an active request, or unexpected disconnect cleanup. The transport memoizes cleanup per connection and waits for any in-progress connection before client disposal resolves. Closing a client does not close sessions that it already created.

## Testing

The red-first patch was run against exact `main` commit `38fe692309495d38073035caa8b0024e5080a40e`. Typechecking failed because `LettaAgentClient` had neither `close()` nor `Symbol.asyncDispose`; the real-process fixture failed at `await using`; and focused transport tests failed because no cleanup API existed.

On macOS arm64, I also ran the original management-only script against the actual API-backed local App Server. The model request completed, but the caller remained alive past the bounded 12-second timeout with a `ChildProcess` and WebSocket handles retained. The historical Linux report that killing the caller can orphan the child was not reproduced on macOS.

The fixed product path uses the actual local harness rather than a fake process. Race tests cover disposal before use, during startup, during an active request, and alongside an independently owned session. Cached Cloud repository and computer namespaces also reject new requests after client disposal.

## Breadcrumbs

- Fixes: https://github.com/letta-ai/letta-agent-sdk/issues/245
- Letta conversation: [`conv-f7390293-9d28-4f40-b2a8-2a2bd5b7fab4`](https://chat.letta.com/chat/agent-ec05a4e0-f50c-47fd-8e7b-960f081ab42e?conversation=conv-f7390293-9d28-4f40-b2a8-2a2bd5b7fab4)
- Origin: Management-only APIs first appeared in https://github.com/letta-ai/letta-agent-sdk/pull/206 without a client disposal contract. Dedicated pooled management connections took their current ownership shape in https://github.com/letta-ai/letta-agent-sdk/pull/218; history did not identify a later single regression that removed client disposal.
- Root-cause evidence: exact-main source trace from `LettaAgentClient.models.list()` through `AppServerManagementTransport.acquireConnection()` to `startLocalAppServer()`, plus the bounded real-process reproduction above.

Written by Cameron ◯ Letta Code

> “The price of reliability is the pursuit of the utmost simplicity.” — C. A. R. Hoare
