### PR TITLE
feat(cloud): support commit-pinned sandbox repositories

### DIFF
--- a/src/cloud-sandbox.ts
+++ b/src/cloud-sandbox.ts
@@ -2,6 +2,8 @@
 export interface GitHubRepositoryRef {
   owner: string;
   repo: string;
+  /** Exact commit to check out after cloning. Omit to use the default branch tip. */
+  commit?: string;
 }
 
 export interface LettaCodeCloudSandboxOptions {
@@ -36,6 +38,7 @@ const MAX_TTL_MINUTES = 60;
 const MAX_GITHUB_REPOSITORIES = 10;
 const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9-]+$/;
 const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+$/;
+const GITHUB_COMMIT_PATTERN = /^[0-9a-fA-F]{40}$/;
 
 function validatePositiveInteger(value: number | undefined, name: string): void {
   if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
@@ -103,6 +106,15 @@ export function validateCloudSandboxOptions(
       ) {
         throw new Error(
           `Invalid ${name}.githubRepositories[${index}].repo.`,
+        );
+      }
+      if (
+        repository.commit !== undefined &&
+        (typeof repository.commit !== "string" ||
+          !GITHUB_COMMIT_PATTERN.test(repository.commit))
+      ) {
+        throw new Error(
+          `Invalid ${name}.githubRepositories[${index}].commit. Expected a full Git commit SHA.`,
         );
       }
     }

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1088,7 +1088,11 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("conv-1", {
       sandbox: {
         githubRepositories: [
-          { owner: "letta-ai", repo: "letta-docs" },
+          {
+            owner: "letta-ai",
+            repo: "letta-docs",
+            commit: "a".repeat(40),
+          },
           { owner: "letta-ai", repo: "letta-code" },
         ],
       },
@@ -1102,7 +1106,11 @@ describe("CloudEnvironmentSession", () => {
         body: {
           conversationId: "conv-1",
           githubRepositories: [
-            { owner: "letta-ai", repo: "letta-docs" },
+            {
+              owner: "letta-ai",
+              repo: "letta-docs",
+              commit: "a".repeat(40),
+            },
             { owner: "letta-ai", repo: "letta-code" },
           ],
         },
@@ -2829,6 +2837,19 @@ describe("CloudEnvironmentSession", () => {
         githubRepositories: [{ owner: "letta-ai", repo: "letta/code" }],
       },
     })).toThrow("githubRepositories[0].repo");
+
+    expect(() => new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      sandbox: {
+        githubRepositories: [
+          { owner: "letta-ai", repo: "letta-code", commit: "main" },
+        ],
+      },
+    })).toThrow("githubRepositories[0].commit");
 
     const clientWithEnvironment = new LettaAgentClient({
       backend: "cloud",


### PR DESCRIPTION
## tl;dr

Agent SDK sessions can ask Cloud to clone GitHub repositories into their managed sandbox, but they could not select an exact revision. This adds an optional full commit SHA to `GitHubRepositoryRef` and forwards it unchanged when the SDK creates the sandbox. Omitting `commit` preserves the current default-branch behavior.

## Testing

The SDK validates full commit SHAs and preserves the value in the managed-sandbox request. The package builds and the complete local test suite passes. A live Cloud sandbox can exercise the commit-pinned path once the updated Cloud API is deployed.

## Breadcrumbs

- Requested in: LET-11864
- Letta conversation: [`conv-424ce74c-49f9-46d3-a339-d24acb2201d8`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-424ce74c-49f9-46d3-a339-d24acb2201d8)